### PR TITLE
Unify route/clinic config source and build-time runtime sync

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -64,7 +64,7 @@
   "scripts": {
     "start": "vite",
     "dev": "vite",
-    "build": "vite build",
+    "build": "node ./scripts/sync-runtime-config.mjs && vite build",
     "preview": "vite preview",
     "test": "vitest",
     "test:e2e": "playwright test",

--- a/frontend/public/config/clinics.json
+++ b/frontend/public/config/clinics.json
@@ -1,14 +1,74 @@
 {
-  "LAB": { "id": "LAB", "name": "Laboratory", "nameAr": "المختبر", "floor": "M" },
-  "EYE": { "id": "EYE", "name": "Ophthalmology", "nameAr": "العيون", "floor": "2" },
-  "INT": { "id": "INT", "name": "Internal Medicine", "nameAr": "الباطنية", "floor": "2" },
-  "SUR": { "id": "SUR", "name": "General Surgery", "nameAr": "الجراحة العامة", "floor": "2" },
-  "ENT": { "id": "ENT", "name": "ENT (Ear, Nose & Throat)", "nameAr": "أنف وأذن وحنجرة", "floor": "2" },
-  "DER": { "id": "DER", "name": "Dermatology", "nameAr": "الجلدية", "floor": "3" },
-  "PSY": { "id": "PSY", "name": "Psychiatry", "nameAr": "الطب النفسي", "floor": "2" },
-  "DNT": { "id": "DNT", "name": "Dentistry", "nameAr": "الأسنان", "floor": "2" },
-  "AUD": { "id": "AUD", "name": "Audiology", "nameAr": "قياس السمع", "floor": "2" },
-  "ECG": { "id": "ECG", "name": "ECG (Electrocardiogram)", "nameAr": "تخطيط القلب", "floor": "2" },
-  "BIO": { "id": "BIO", "name": "Biometrics", "nameAr": "القياسات الحيوية", "floor": "2" },
-  "XR":  { "id": "XR",  "name": "Radiology", "nameAr": "الأشعة", "floor": "M" }
+  "LAB": {
+    "id": "LAB",
+    "name": "Laboratory",
+    "nameAr": "المختبر",
+    "floor": "M"
+  },
+  "EYE": {
+    "id": "EYE",
+    "name": "Ophthalmology",
+    "nameAr": "العيون",
+    "floor": "2"
+  },
+  "INT": {
+    "id": "INT",
+    "name": "Internal Medicine",
+    "nameAr": "الباطنية",
+    "floor": "2"
+  },
+  "SUR": {
+    "id": "SUR",
+    "name": "General Surgery",
+    "nameAr": "الجراحة العامة",
+    "floor": "2"
+  },
+  "ENT": {
+    "id": "ENT",
+    "name": "ENT (Ear, Nose & Throat)",
+    "nameAr": "أنف وأذن وحنجرة",
+    "floor": "2"
+  },
+  "DER": {
+    "id": "DER",
+    "name": "Dermatology",
+    "nameAr": "الجلدية",
+    "floor": "3"
+  },
+  "PSY": {
+    "id": "PSY",
+    "name": "Psychiatry",
+    "nameAr": "الطب النفسي",
+    "floor": "2"
+  },
+  "DNT": {
+    "id": "DNT",
+    "name": "Dentistry",
+    "nameAr": "الأسنان",
+    "floor": "2"
+  },
+  "AUD": {
+    "id": "AUD",
+    "name": "Audiology",
+    "nameAr": "قياس السمع",
+    "floor": "2"
+  },
+  "ECG": {
+    "id": "ECG",
+    "name": "ECG (Electrocardiogram)",
+    "nameAr": "تخطيط القلب",
+    "floor": "2"
+  },
+  "BIO": {
+    "id": "BIO",
+    "name": "Biometrics",
+    "nameAr": "القياسات الحيوية",
+    "floor": "2"
+  },
+  "XR": {
+    "id": "XR",
+    "name": "Radiology",
+    "nameAr": "الأشعة",
+    "floor": "M"
+  }
 }

--- a/frontend/public/config/routeMap.json
+++ b/frontend/public/config/routeMap.json
@@ -1,15 +1,98 @@
 {
-  "دورات": ["LAB","EYE","SUR","INT"],
-  "تجنيد": ["LAB","XR","BIO","EYE","INT","SUR","ENT","PSY","DNT","DER"],
-  "ترفيع": ["LAB","XR","BIO","EYE","INT","SUR","ENT","PSY","DNT","DER"],
-  "نقل":   ["LAB","XR","BIO","EYE","INT","SUR","ENT","PSY","DNT","DER"],
-  "تحويل": ["LAB","XR","BIO","EYE","INT","SUR","ENT","PSY","DNT","DER"],
-  "تجديد التعاقد": ["LAB","XR","BIO","EYE","INT","SUR","ENT","PSY","DNT","DER"],
-  "طيران سنوي": ["LAB","EYE","INT","ENT","ECG","AUD"],
-  "طباخين": ["LAB","INT","ENT","SUR"],
+  "دورات": [
+    "LAB",
+    "EYE",
+    "SUR",
+    "INT"
+  ],
+  "تجنيد": [
+    "LAB",
+    "XR",
+    "BIO",
+    "EYE",
+    "INT",
+    "SUR",
+    "ENT",
+    "PSY",
+    "DNT",
+    "DER"
+  ],
+  "ترفيع": [
+    "LAB",
+    "XR",
+    "BIO",
+    "EYE",
+    "INT",
+    "SUR",
+    "ENT",
+    "PSY",
+    "DNT",
+    "DER"
+  ],
+  "نقل": [
+    "LAB",
+    "XR",
+    "BIO",
+    "EYE",
+    "INT",
+    "SUR",
+    "ENT",
+    "PSY",
+    "DNT",
+    "DER"
+  ],
+  "تحويل": [
+    "LAB",
+    "XR",
+    "BIO",
+    "EYE",
+    "INT",
+    "SUR",
+    "ENT",
+    "PSY",
+    "DNT",
+    "DER"
+  ],
+  "تجديد التعاقد": [
+    "LAB",
+    "XR",
+    "BIO",
+    "EYE",
+    "INT",
+    "SUR",
+    "ENT",
+    "PSY",
+    "DNT",
+    "DER"
+  ],
+  "طيران سنوي": [
+    "LAB",
+    "EYE",
+    "INT",
+    "ENT",
+    "ECG",
+    "AUD"
+  ],
+  "طباخين": [
+    "LAB",
+    "INT",
+    "ENT",
+    "SUR"
+  ],
   "نساء/عام": {
     "prefix": "الاستقبال الرئيسي - الطابق الأرضي (العطار)",
-    "M": ["LAB","XR","BIO","ENT","SUR","DNT"],
-    "F": ["INT","EYE","DER"]
+    "M": [
+      "LAB",
+      "XR",
+      "BIO",
+      "ENT",
+      "SUR",
+      "DNT"
+    ],
+    "F": [
+      "INT",
+      "EYE",
+      "DER"
+    ]
   }
 }

--- a/frontend/scripts/sync-runtime-config.mjs
+++ b/frontend/scripts/sync-runtime-config.mjs
@@ -1,0 +1,32 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const frontendRoot = path.resolve(__dirname, '..');
+
+const sources = [
+  'routeMap.json',
+  'clinics.json',
+];
+
+async function sync() {
+  const srcDir = path.join(frontendRoot, 'config');
+  const destDir = path.join(frontendRoot, 'public', 'config');
+  await mkdir(destDir, { recursive: true });
+
+  for (const filename of sources) {
+    const src = path.join(srcDir, filename);
+    const dest = path.join(destDir, filename);
+    const payload = await readFile(src, 'utf8');
+    const normalized = `${JSON.stringify(JSON.parse(payload), null, 2)}\n`;
+    await writeFile(dest, normalized, 'utf8');
+    console.log(`synced ${filename}`);
+  }
+}
+
+sync().catch((err) => {
+  console.error('Failed to sync runtime config:', err);
+  process.exitCode = 1;
+});

--- a/src/core/routing/configLoader.ts
+++ b/src/core/routing/configLoader.ts
@@ -1,0 +1,27 @@
+import * as path from 'path';
+import { readJSON } from '../../utils/fs-atomic.js';
+
+const FRONTEND_CONFIG_DIR = path.join(process.cwd(), 'frontend', 'config');
+const LEGACY_CONFIG_DIR = path.join(process.cwd(), 'config');
+
+function resolveConfigPath(filename: 'routeMap.json' | 'clinics.json') {
+  return {
+    canonical: path.join(FRONTEND_CONFIG_DIR, filename),
+    legacy: path.join(LEGACY_CONFIG_DIR, filename),
+  };
+}
+
+async function loadConfigFile<T>(filename: 'routeMap.json' | 'clinics.json'): Promise<T> {
+  const { canonical, legacy } = resolveConfigPath(filename);
+  const fromCanonical = await readJSON<T | null>(canonical, null);
+  if (fromCanonical) return fromCanonical;
+  return await readJSON<T>(legacy, {} as T);
+}
+
+export async function loadRouteMap() {
+  return loadConfigFile<Record<string, any>>('routeMap.json');
+}
+
+export async function loadClinics() {
+  return loadConfigFile<Record<string, any>>('clinics.json');
+}

--- a/src/core/routing/routeMapService.ts
+++ b/src/core/routing/routeMapService.ts
@@ -1,9 +1,5 @@
-import { readJSON } from '../../utils/fs-atomic.js';
-import * as path from 'path';
-
-const ROUTE_MAP_FILE = path.join(process.cwd(), 'config', 'routeMap.json');
+import { loadRouteMap } from './configLoader.js';
 
 export async function getRouteMap() {
-  return await readJSON(ROUTE_MAP_FILE, {});
+  return await loadRouteMap();
 }
-

--- a/src/core/routing/routeService.ts
+++ b/src/core/routing/routeService.ts
@@ -3,8 +3,7 @@ import { writeAtomicJSON, readJSON } from '../../utils/fs-atomic.js';
 import { localDateKeyAsiaQatar, nowISO } from '../../utils/time.js';
 import { appendAudit } from '../../utils/logger.js';
 
-import ROUTE_MAP from "../../../config/routeMap.json" with { type: "json" };
-import CLINICS from "../../../config/clinics.json" with { type: "json" };
+import { loadRouteMap, loadClinics } from "./configLoader.js";
 
 type RouteFile = {
   visitId: string;
@@ -17,9 +16,10 @@ type RouteFile = {
 const filePath = (visitId:string) => path.join('data','routes', `${visitId}.json`);
 
 export async function createRoute(visitId:string, examType:string, gender?:'M'|'F') {
-  const steps: string[] = Array.isArray((ROUTE_MAP as any)[examType]) ? (ROUTE_MAP as any)[examType] as string[] :
+  const routeMap = await loadRouteMap();
+  const steps: string[] = Array.isArray((routeMap as any)[examType]) ? (routeMap as any)[examType] as string[] :
     // للحالات الخاصة (نساء)
-    (gender === 'F' && (ROUTE_MAP as any)['نساء/عام']?.F) ? (ROUTE_MAP as any)['نساء/عام']?.F as string[] : ((ROUTE_MAP as any)['نساء/عام']?.M || []) as string[];
+    (gender === 'F' && (routeMap as any)['نساء/عام']?.F) ? (routeMap as any)['نساء/عام']?.F as string[] : ((routeMap as any)['نساء/عام']?.M || []) as string[];
   const route: RouteFile = {
     visitId, examType, gender,
     route: steps.map(c=>({ clinicId:c })),
@@ -41,7 +41,8 @@ export async function assignFirstClinicTicket(visitId:string, assignFn:(cid:stri
   first.assigned = { ticket, dateKey, issuedAt: nowISO() };
   await writeAtomicJSON(filePath(visitId), rf);
   await appendAudit(`route.ticket.assigned visit=${visitId} clinic=${first.clinicId} ticket=${ticket}`);
-  return { ...first, floorHint: (CLINICS as any)[first.clinicId].floor };
+  const clinics = await loadClinics();
+  return { ...first, floorHint: (clinics as any)[first.clinicId]?.floor };
 }
 
 export async function getRoute(visitId:string) {
@@ -66,5 +67,6 @@ export async function getNextClinic(visitId:string) {
   if (!rf) throw new Error('ROUTE_NOT_FOUND');
   const next = rf.route.find((x: { status?: string; }) => !x.status);
   if (!next) return { done: true };
-  return { clinicId: next.clinicId, floorHint: (CLINICS as any)[next.clinicId].floor };
+  const clinics = await loadClinics();
+  return { clinicId: next.clinicId, floorHint: (clinics as any)[next.clinicId]?.floor };
 }


### PR DESCRIPTION
### Motivation
- Remove duplicated config reads and select a single canonical source for routing/clinic definitions (`frontend/config/*`).
- Ensure any publicly exposed runtime JSON is generated deterministically during the frontend build, avoiding drift between private and public copies.
- Consolidate config-loading logic so server code and future consumers share the same resolution/fallback behavior.

### Description
- Added a centralized loader `src/core/routing/configLoader.ts` that prefers `frontend/config/{routeMap.json,clinics.json}` and falls back to legacy `config/*` when missing.
- Updated routing services to use the loader: `src/core/routing/routeService.ts` and `src/core/routing/routeMapService.ts` now call `loadRouteMap()` / `loadClinics()` instead of importing or reading JSON directly.
- Added deterministic build-time sync script `frontend/scripts/sync-runtime-config.mjs` which normalizes and copies JSON from `frontend/config` to `frontend/public/config` for runtime consumption.
- Wired the sync step into the frontend build by updating `frontend/package.json` `build` script to run the sync before `vite build`.

### Testing
- Ran `node ./frontend/scripts/sync-runtime-config.mjs` successfully and verified `frontend/public/config/{routeMap.json,clinics.json}` were written and normalized (success).
- Ran `npm run build` in `frontend`: the sync step ran successfully but the subsequent `vite build` failed due to an unresolved import `@vercel/speed-insights/react` in the current environment/dependency state (pre-existing dependency issue), so the full build is blocked by that unrelated resolver error (sync step itself succeeded).
- No automated unit tests were modified in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bfd05b634832a8e0539d6a4b69e2b)