### PR TITLE
refactor(frontend): replace server-side db access with Supabase client in routingManager

### DIFF
--- a/frontend/src/lib/routingManager.js
+++ b/frontend/src/lib/routingManager.js
@@ -1,86 +1,52 @@
 // lib/routingManager.js - مدير التوجيه الديناميكي مع الأوزان والسعة
-import db from '../../../src/lib/supabase-db.js';
+import { supabase } from './supabase-client.js';
 import { getSystemConfig } from './settings.js';
 
-/**
- * نوع بيانات نقاط العيادة
- * @typedef {Object} ClinicScore
- * @property {number} id - معرف العيادة
- * @property {string} name - اسم العيادة
- * @property {number} loadRatio - نسبة الحمل (0-1)
- * @property {number} distributedToday - عدد المراجعين الموزعين اليوم
- * @property {number} capacity - السعة القصوى
- * @property {number} currentLoad - الحمل الحالي
- * @property {number} score - النقاط الإجمالية للترتيب
- */
+async function fetchClinicLoadMap(clinicIds) {
+  const { data, error } = await supabase
+    .from('clinic_load')
+    .select('clinic_id, current_called, current_in, distributed_today, total_served_today, efficiency_score, updated_at')
+    .in('clinic_id', clinicIds);
 
-/**
- * اختيار أفضل عيادة للخطوة التالية بناءً على الحمل والتوزيع
- * @param {string} examType - نوع الفحص
- * @param {string} gender - جنس المراجع
- * @param {number} currentStep - رقم الخطوة الحالية
- * @returns {Promise<number|null>} معرف العيادة المختارة أو null
- */
+  if (error) throw error;
+
+  return new Map((data || []).map((row) => [row.clinic_id, row]));
+}
+
 export async function pickClinicForNextStep(examType, gender, currentStep = 1) {
   try {
-    // جلب العيادات المتاحة لهذا النوع من الفحص والجنس
-    const { rows: availableClinics } = await db.query(`
-      SELECT DISTINCT
-        c.id, c.name, c.capacity, c.status,
-        ert.step_order, ert.estimated_duration_minutes
-      FROM clinics c
-      JOIN exam_route_templates ert ON ert.clinic_id = c.id
-      WHERE ert.exam_type = $1 
-        AND ert.gender = $2 
-        AND ert.step_order = $3
-        AND c.status = 'open'
-      ORDER BY ert.step_order
-    `, [examType, gender, currentStep]);
+    const { data: routeRows, error: routeError } = await supabase
+      .from('exam_route_templates')
+      .select('step_order, estimated_duration_minutes, clinic:clinics!inner(id, name, capacity, status)')
+      .eq('exam_type', examType)
+      .eq('gender', gender)
+      .eq('step_order', currentStep)
+      .eq('clinics.status', 'open');
 
-    if (availableClinics.length === 0) {
+    if (routeError) throw routeError;
 
-      return null;
-    }
+    const availableClinics = (routeRows || []).map((row) => ({
+      id: row.clinic.id,
+      name: row.clinic.name,
+      capacity: row.clinic.capacity,
+      estimated_duration_minutes: row.estimated_duration_minutes,
+    }));
 
-    // جلب الحمل الحالي لكل عيادة
-    const clinicIds = availableClinics.map(c => c.id);
-    const { rows: loadData } = await db.query(`
-      SELECT 
-        c.id,
-        COALESCE(cl.current_called, 0) + COALESCE(cl.current_in, 0) as current_load,
-        COALESCE(cl.distributed_today, 0) as distributed_today,
-        COALESCE(cl.efficiency_score, 1.0) as efficiency_score,
-        c.capacity
-      FROM clinics c
-      LEFT JOIN clinic_load cl ON cl.clinic_id = c.id
-      WHERE c.id = ANY($1)
-    `, [clinicIds]);
+    if (availableClinics.length === 0) return null;
 
-    // حساب النقاط لكل عيادة
-    const scoredClinics = availableClinics.map(clinic => {
-      const loadInfo = loadData.find(l => l.id === clinic.id) || {
-        current_load: 0,
-        distributed_today: 0,
-        efficiency_score: 1.0
-      };
+    const clinicIds = availableClinics.map((c) => c.id);
+    const loadMap = await fetchClinicLoadMap(clinicIds);
+    const maxDistributed = Math.max(...Array.from(loadMap.values()).map((l) => l.distributed_today || 0), 1);
 
+    const scoredClinics = availableClinics.map((clinic) => {
+      const loadInfo = loadMap.get(clinic.id) || {};
+      const currentLoad = (loadInfo.current_called || 0) + (loadInfo.current_in || 0);
+      const distributedToday = loadInfo.distributed_today || 0;
       const capacity = clinic.capacity || 6;
-      const loadRatio = loadInfo.current_load / capacity;
-      const distributedToday = loadInfo.distributed_today;
-      const efficiencyScore = parseFloat(loadInfo.efficiency_score);
+      const loadRatio = currentLoad / capacity;
+      const efficiencyScore = parseFloat(loadInfo.efficiency_score ?? 1);
 
-      // حساب النقاط (أقل نقاط = أفضل اختيار)
-      let score = 0;
-      
-      // وزن الحمل الحالي (70% من النقاط)
-      score += loadRatio * 0.7;
-      
-      // وزن التوزيع اليومي (20% من النقاط)
-      const maxDistributed = Math.max(...loadData.map(l => l.distributed_today), 1);
-      score += (distributedToday / maxDistributed) * 0.2;
-      
-      // وزن الكفاءة (10% من النقاط - كفاءة أقل = نقاط أكثر)
-      score += (1 - efficiencyScore) * 0.1;
+      const score = (loadRatio * 0.7) + ((distributedToday / maxDistributed) * 0.2) + ((1 - efficiencyScore) * 0.1);
 
       return {
         id: clinic.id,
@@ -88,340 +54,263 @@ export async function pickClinicForNextStep(examType, gender, currentStep = 1) {
         loadRatio,
         distributedToday,
         capacity,
-        currentLoad: loadInfo.current_load,
+        currentLoad,
         efficiencyScore,
         score,
-        estimatedDuration: clinic.estimated_duration_minutes
       };
     });
 
-    // ترتيب العيادات حسب النقاط (الأقل أولاً)
     scoredClinics.sort((a, b) => {
-      // أولوية للعيادات التي لم تصل للسعة القصوى
       if (a.currentLoad >= a.capacity && b.currentLoad < b.capacity) return 1;
       if (b.currentLoad >= b.capacity && a.currentLoad < a.capacity) return -1;
-      
-      // ثم حسب النقاط
       return a.score - b.score;
     });
 
-    const selectedClinic = scoredClinics[0];
-    return selectedClinic?.id || null;
-
-  } catch (error) {
-    // console.error('Error picking clinic for next step:', error);
+    return scoredClinics[0]?.id || null;
+  } catch {
     return null;
   }
 }
 
-/**
- * تسجيل توزيع مراجع جديد على عيادة
- * @param {number} clinicId - معرف العيادة
- * @returns {Promise<boolean>} نجح التسجيل أم لا
- */
 export async function markDistributed(clinicId) {
   try {
-    await db.query(`
-      INSERT INTO clinic_load(clinic_id, current_called, current_in, distributed_today, updated_at)
-      VALUES($1, 0, 0, 1, NOW())
-      ON CONFLICT (clinic_id) DO UPDATE SET
-        distributed_today = clinic_load.distributed_today + 1,
-        updated_at = NOW()
-    `, [clinicId]);
+    const now = new Date().toISOString();
+    const today = new Date().toISOString().slice(0, 10);
 
-    // تحديث الإحصائيات اليومية
-    await db.query(`
-      INSERT INTO daily_clinic_stats(clinic_id, date, total_patients)
-      VALUES($1, CURRENT_DATE, 1)
-      ON CONFLICT (clinic_id, date) DO UPDATE SET
-        total_patients = daily_clinic_stats.total_patients + 1
-    `, [clinicId]);
+    const { data: existing, error: loadReadError } = await supabase
+      .from('clinic_load')
+      .select('distributed_today')
+      .eq('clinic_id', clinicId)
+      .maybeSingle();
+    if (loadReadError) throw loadReadError;
+
+    const { error: loadWriteError } = await supabase
+      .from('clinic_load')
+      .upsert({
+        clinic_id: clinicId,
+        current_called: 0,
+        current_in: 0,
+        distributed_today: (existing?.distributed_today || 0) + 1,
+        updated_at: now,
+      }, { onConflict: 'clinic_id' });
+    if (loadWriteError) throw loadWriteError;
+
+    const { data: statExisting, error: statReadError } = await supabase
+      .from('daily_clinic_stats')
+      .select('total_patients')
+      .eq('clinic_id', clinicId)
+      .eq('date', today)
+      .maybeSingle();
+    if (statReadError) throw statReadError;
+
+    const { error: statWriteError } = await supabase
+      .from('daily_clinic_stats')
+      .upsert({
+        clinic_id: clinicId,
+        date: today,
+        total_patients: (statExisting?.total_patients || 0) + 1,
+      }, { onConflict: 'clinic_id,date' });
+    if (statWriteError) throw statWriteError;
 
     return true;
-  } catch (error) {
-    // console.error(`Error marking distributed for clinic ${clinicId}:`, error);
+  } catch {
     return false;
   }
 }
 
-/**
- * جلب المسار الكامل لنوع فحص وجنس معين
- * @param {string} examType - نوع الفحص
- * @param {string} gender - جنس المراجع
- * @returns {Promise<Array>} مصفوفة خطوات المسار
- */
 export async function getExamRoute(examType, gender) {
   try {
-    const { rows } = await db.query(`
-      SELECT 
-        ert.step_order,
-        ert.clinic_id,
-        c.name as clinic_name,
-        c.floor,
-        ert.is_required,
-        ert.estimated_duration_minutes
-      FROM exam_route_templates ert
-      JOIN clinics c ON c.id = ert.clinic_id
-      WHERE ert.exam_type = $1 AND ert.gender = $2
-      ORDER BY ert.step_order
-    `, [examType, gender]);
+    const { data, error } = await supabase
+      .from('exam_route_templates')
+      .select('step_order, clinic_id, is_required, estimated_duration_minutes, clinic:clinics!inner(name, floor)')
+      .eq('exam_type', examType)
+      .eq('gender', gender)
+      .order('step_order', { ascending: true });
 
-    return rows.map(row => ({
+    if (error) throw error;
+
+    return (data || []).map((row) => ({
       stepOrder: row.step_order,
       clinicId: row.clinic_id,
-      clinicName: row.clinic_name,
-      floor: row.floor,
+      clinicName: row.clinic.name,
+      floor: row.clinic.floor,
       isRequired: row.is_required,
-      estimatedDuration: row.estimated_duration_minutes
+      estimatedDuration: row.estimated_duration_minutes,
     }));
-  } catch (error) {
-    // console.error(`Error getting exam route for ${examType}/${gender}:`, error);
+  } catch {
     return [];
   }
 }
 
-/**
- * إنشاء مسار جديد لمراجع
- * @param {string} patientId - معرف المراجع
- * @param {string} examType - نوع الفحص
- * @param {string} gender - جنس المراجع
- * @returns {Promise<boolean>} نجح الإنشاء أم لا
- */
 export async function createPatientRoute(patientId, examType, gender) {
-  const client = await db.getClient();
-  
   try {
-    await client.query('BEGIN');
-
-    // حذف أي مسار سابق للمراجع (في حالة إعادة البدء)
-    await client.query(`
-      DELETE FROM patient_routes WHERE patient_id = $1
-    `, [patientId]);
-
-    // جلب قالب المسار
     const routeTemplate = await getExamRoute(examType, gender);
-    
-    if (routeTemplate.length === 0) {
-      throw new Error(`No route template found for ${examType}/${gender}`);
-    }
+    if (routeTemplate.length === 0) return false;
 
-    // إنشاء خطوات المسار
-    for (const step of routeTemplate) {
-      await client.query(`
-        INSERT INTO patient_routes(
-          patient_id, exam_type, gender, step_order, clinic_id, status
-        ) VALUES ($1, $2, $3, $4, $5, $6)
-      `, [
-        patientId, examType, gender, 
-        step.stepOrder, step.clinicId, 
-        step.stepOrder === 1 ? 'active' : 'pending'
-      ]);
-    }
+    const { error: deleteError } = await supabase.from('patient_routes').delete().eq('patient_id', patientId);
+    if (deleteError) throw deleteError;
 
-    await client.query('COMMIT');
+    const payload = routeTemplate.map((step) => ({
+      patient_id: patientId,
+      exam_type: examType,
+      gender,
+      step_order: step.stepOrder,
+      clinic_id: step.clinicId,
+      status: step.stepOrder === 1 ? 'active' : 'pending',
+    }));
+
+    const { error: insertError } = await supabase.from('patient_routes').insert(payload);
+    if (insertError) throw insertError;
+
     return true;
-
-  } catch (error) {
-    await client.query('ROLLBACK');
-    // console.error(`Error creating patient route for ${patientId}:`, error);
+  } catch {
     return false;
-  } finally {
-    client.release();
   }
 }
 
-/**
- * الانتقال للخطوة التالية في المسار
- * @param {string} patientId - معرف المراجع
- * @returns {Promise<Object|null>} معلومات الخطوة التالية أو null
- */
 export async function moveToNextStep(patientId) {
-  const client = await db.getClient();
-  
   try {
-    await client.query('BEGIN');
+    const { data: currentStepRows, error: currentError } = await supabase
+      .from('patient_routes')
+      .select('id, step_order, clinic_id, exam_type, gender')
+      .eq('patient_id', patientId)
+      .eq('status', 'active')
+      .order('step_order', { ascending: true })
+      .limit(1);
 
-    // جلب الخطوة النشطة الحالية
-    const { rows: currentStep } = await client.query(`
-      SELECT id, step_order, clinic_id, exam_type, gender
-      FROM patient_routes
-      WHERE patient_id = $1 AND status = 'active'
-      ORDER BY step_order ASC
-      LIMIT 1
-    `, [patientId]);
+    if (currentError) throw currentError;
+    if (!currentStepRows?.length) return null;
 
-    if (currentStep.length === 0) {
-      await client.query('ROLLBACK');
-      return null;
-    }
+    const current = currentStepRows[0];
+    const now = new Date().toISOString();
 
-    const current = currentStep[0];
+    const { error: doneError } = await supabase
+      .from('patient_routes')
+      .update({ status: 'done', completed_at: now, updated_at: now })
+      .eq('id', current.id);
+    if (doneError) throw doneError;
 
-    // تحديث الخطوة الحالية إلى مكتملة
-    await client.query(`
-      UPDATE patient_routes
-      SET status = 'done', completed_at = NOW(), updated_at = NOW()
-      WHERE id = $1
-    `, [current.id]);
+    const { data: nextRows, error: nextError } = await supabase
+      .from('patient_routes')
+      .select('id, step_order, clinic_id')
+      .eq('patient_id', patientId)
+      .eq('status', 'pending')
+      .gt('step_order', current.step_order)
+      .order('step_order', { ascending: true })
+      .limit(1);
+    if (nextError) throw nextError;
 
-    // البحث عن الخطوة التالية
-    const { rows: nextStep } = await client.query(`
-      SELECT id, step_order, clinic_id
-      FROM patient_routes
-      WHERE patient_id = $1 AND status = 'pending' AND step_order > $2
-      ORDER BY step_order ASC
-      LIMIT 1
-    `, [patientId, current.step_order]);
-
-    if (nextStep.length === 0) {
-      // انتهى المسار
-      await client.query(`
-        SELECT create_notification(
-          'route_complete',
-          $1,
-          NULL,
-          '{}'::jsonb
-        )
-      `, [patientId]);
-
-      await client.query('COMMIT');
+    if (!nextRows?.length) {
+      await supabase.rpc('create_notification', {
+        p_type: 'route_complete',
+        p_patient_id: patientId,
+        p_clinic_id: null,
+        p_payload: {},
+      });
       return { completed: true, message: 'تم إنهاء جميع الفحوصات المطلوبة' };
     }
 
-    const next = nextStep[0];
+    const next = nextRows[0];
+    const { error: activateError } = await supabase
+      .from('patient_routes')
+      .update({ status: 'active', started_at: now, updated_at: now })
+      .eq('id', next.id);
+    if (activateError) throw activateError;
 
-    // تفعيل الخطوة التالية
-    await client.query(`
-      UPDATE patient_routes
-      SET status = 'active', started_at = NOW(), updated_at = NOW()
-      WHERE id = $1
-    `, [next.id]);
-
-    // جلب معلومات العيادة التالية
-    const { rows: clinicInfo } = await client.query(`
-      SELECT name, floor FROM clinics WHERE id = $1
-    `, [next.clinic_id]);
-
-    await client.query('COMMIT');
+    const { data: clinicInfo, error: clinicError } = await supabase
+      .from('clinics')
+      .select('name, floor')
+      .eq('id', next.clinic_id)
+      .maybeSingle();
+    if (clinicError) throw clinicError;
 
     return {
       completed: false,
       nextStep: {
         stepOrder: next.step_order,
         clinicId: next.clinic_id,
-        clinicName: clinicInfo[0]?.name,
-        floor: clinicInfo[0]?.floor
-      }
+        clinicName: clinicInfo?.name,
+        floor: clinicInfo?.floor,
+      },
     };
-
-  } catch (error) {
-    await client.query('ROLLBACK');
-    // console.error(`Error moving to next step for patient ${patientId}:`, error);
+  } catch {
     return null;
-  } finally {
-    client.release();
   }
 }
 
-/**
- * جلب حالة المسار الحالية للمراجع
- * @param {string} patientId - معرف المراجع
- * @returns {Promise<Object>} حالة المسار
- */
 export async function getPatientRouteStatus(patientId) {
   try {
-    const { rows } = await db.query(`
-      SELECT 
-        pr.step_order,
-        pr.clinic_id,
-        c.name as clinic_name,
-        c.floor,
-        pr.status,
-        pr.started_at,
-        pr.completed_at,
-        pr.exam_type,
-        pr.gender
-      FROM patient_routes pr
-      JOIN clinics c ON c.id = pr.clinic_id
-      WHERE pr.patient_id = $1
-      ORDER BY pr.step_order
-    `, [patientId]);
+    const { data, error } = await supabase
+      .from('patient_routes')
+      .select('step_order, clinic_id, status, started_at, completed_at, exam_type, gender, clinic:clinics!inner(name, floor)')
+      .eq('patient_id', patientId)
+      .order('step_order', { ascending: true });
+    if (error) throw error;
 
-    if (rows.length === 0) {
-      return { exists: false, steps: [] };
-    }
+    if (!data?.length) return { exists: false, steps: [] };
 
-    const steps = rows.map(row => ({
+    const steps = data.map((row) => ({
       stepOrder: row.step_order,
       clinicId: row.clinic_id,
-      clinicName: row.clinic_name,
-      floor: row.floor,
+      clinicName: row.clinic.name,
+      floor: row.clinic.floor,
       status: row.status,
       startedAt: row.started_at,
-      completedAt: row.completed_at
+      completedAt: row.completed_at,
     }));
 
-    const activeStep = steps.find(s => s.status === 'active');
-    const completedSteps = steps.filter(s => s.status === 'done').length;
+    const activeStep = steps.find((s) => s.status === 'active');
+    const completedSteps = steps.filter((s) => s.status === 'done').length;
     const totalSteps = steps.length;
-    const progress = (completedSteps / totalSteps) * 100;
 
     return {
       exists: true,
-      examType: rows[0].exam_type,
-      gender: rows[0].gender,
+      examType: data[0].exam_type,
+      gender: data[0].gender,
       steps,
       activeStep,
-      progress: Math.round(progress),
+      progress: Math.round((completedSteps / totalSteps) * 100),
       completedSteps,
       totalSteps,
-      isComplete: completedSteps === totalSteps
+      isComplete: completedSteps === totalSteps,
     };
   } catch (error) {
-    // console.error(`Error getting route status for patient ${patientId}:`, error);
     return { exists: false, steps: [], error: error.message };
   }
 }
 
-/**
- * جلب إحصائيات التوزيع لجميع العيادات
- * @returns {Promise<Array>} إحصائيات التوزيع
- */
 export async function getDistributionStats() {
   try {
-    const { rows } = await db.query(`
-      SELECT 
-        c.id,
-        c.name,
-        c.capacity,
-        c.status,
-        COALESCE(cl.current_called, 0) as current_called,
-        COALESCE(cl.current_in, 0) as current_in,
-        COALESCE(cl.distributed_today, 0) as distributed_today,
-        COALESCE(cl.total_served_today, 0) as total_served_today,
-        COALESCE(cl.efficiency_score, 1.0) as efficiency_score,
-        cl.updated_at
-      FROM clinics c
-      LEFT JOIN clinic_load cl ON cl.clinic_id = c.id
-      ORDER BY c.name
-    `);
+    const { data: clinics, error: clinicsError } = await supabase
+      .from('clinics')
+      .select('id, name, capacity, status')
+      .order('name', { ascending: true });
+    if (clinicsError) throw clinicsError;
 
-    return rows.map(row => ({
-      clinicId: row.id,
-      name: row.name,
-      capacity: row.capacity,
-      status: row.status,
-      currentCalled: row.current_called,
-      currentIn: row.current_in,
-      currentTotal: row.current_called + row.current_in,
-      distributedToday: row.distributed_today,
-      totalServedToday: row.total_served_today,
-      loadRatio: (row.current_called + row.current_in) / row.capacity,
-      efficiencyScore: parseFloat(row.efficiency_score),
-      lastUpdated: row.updated_at
-    }));
-  } catch (error) {
-    // console.error('Error getting distribution stats:', error);
+    const loadMap = await fetchClinicLoadMap((clinics || []).map((c) => c.id));
+
+    return (clinics || []).map((clinic) => {
+      const load = loadMap.get(clinic.id) || {};
+      const currentCalled = load.current_called || 0;
+      const currentIn = load.current_in || 0;
+      const capacity = clinic.capacity || 1;
+
+      return {
+        clinicId: clinic.id,
+        name: clinic.name,
+        capacity: clinic.capacity,
+        status: clinic.status,
+        currentCalled,
+        currentIn,
+        currentTotal: currentCalled + currentIn,
+        distributedToday: load.distributed_today || 0,
+        totalServedToday: load.total_served_today || 0,
+        loadRatio: (currentCalled + currentIn) / capacity,
+        efficiencyScore: parseFloat(load.efficiency_score ?? 1),
+        lastUpdated: load.updated_at,
+      };
+    });
+  } catch {
     return [];
   }
 }
@@ -433,5 +322,6 @@ export default {
   createPatientRoute,
   moveToNextStep,
   getPatientRouteStatus,
-  getDistributionStats
+  getDistributionStats,
+  getSystemConfig,
 };


### PR DESCRIPTION
### Motivation
- Prevent server-side Node/Postgres code from being bundled into the frontend by removing the `../../../src/lib/supabase-db.js` dependency from frontend modules. 
- Ensure frontend modules use the browser-safe Supabase client abstraction so data access is compatible with Vite/browser builds. 
- Preserve the existing routing manager API while moving server-only transactional patterns out of the frontend scope.

### Description
- Replaced the server `db` import with the browser-safe `supabase` client by importing `./supabase-client.js` in `frontend/src/lib/routingManager.js` and switching all `db.query` and `db.getClient` usages to Supabase client calls. 
- Implemented `fetchClinicLoadMap` helper to fetch and map `clinic_load` rows and used it to compute clinic scores instead of running server-side joins/SQL. 
- Converted transactional flows (previously using `BEGIN/COMMIT/ROLLBACK` via `db.getClient()`) to sequential Supabase calls in the frontend and preserved the method signatures (`pickClinicForNextStep`, `markDistributed`, `getExamRoute`, `createPatientRoute`, `moveToNextStep`, `getPatientRouteStatus`, `getDistributionStats`). 
- Kept behavior parity where practical and added defensive checks/`maybeSingle`-style handling for frontend-safe queries; noted that strict transactional guarantees should be implemented on backend RPCs if required.

### Testing
- Verified there are no remaining targeted server-db references by running `rg -n "import db from '../../../src/lib/supabase-db.js'|db\.query\(|db\.getClient\(" frontend/src/lib/settings.js frontend/src/lib/routingManager.js -S` which confirmed the routing manager no longer imports or calls server-only APIs. 
- Attempted a production build with `cd frontend && npm run build`, which failed due to an unrelated pre-existing module resolution error for `@vercel/speed-insights/react` in `frontend/src/App.jsx`, and therefore the build did not complete successfully. 
- No other automated test suites were run as part of this change; the refactor is limited to frontend-safe API replacements and should be followed by running the full CI/build after resolving the unrelated dependency issue.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bfd014d04832aa50095645ee10d4f)