### PR TITLE
refactor(auth): remove hardcoded admin fallback and standardize admin RPC response

### DIFF
--- a/frontend/src/lib/api-unified.js
+++ b/frontend/src/lib/api-unified.js
@@ -500,35 +500,29 @@ const api = {
 
   async adminLogin(username, password) {
     try {
-      if (username === 'Bomussa' && password === '14490') {
-        return { success: true, role: 'SUPER_ADMIN', data: { id: 'super_admin', username: 'Bomussa', role: 'SUPER_ADMIN' } };
+      const { data: result, error } = await supabase.rpc('admin_login', {
+        p_username: username,
+        p_password: password,
+      });
+
+      if (error) {
+        return { success: false, error: error.message };
       }
 
-      const { data: doctor, error: docError } = await supabase
-        .from('doctors')
-        .select('*')
-        .eq('username', username.toLowerCase())
-        .eq('is_active', true)
-        .maybeSingle();
-
-      if (docError) throw docError;
-
-      if (doctor) {
-        const passwordMatch = doctor.password_hash
-          ? doctor.password_hash === password || doctor.password_hash === await (async () => {
-              const encoder = new TextEncoder();
-              const data = encoder.encode(password);
-              const hash = await crypto.subtle.digest('SHA-256', data);
-              return Array.from(new Uint8Array(hash)).map((b) => b.toString(16).padStart(2, '0')).join('');
-            })()
-          : doctor.password === password;
-
-        if (passwordMatch) {
-          return { success: true, role: doctor.role || 'DOCTOR', data: doctor };
-        }
+      if (result?.success && result?.data) {
+        return {
+          success: true,
+          data: {
+            ...result.data,
+            role: result.data.role || 'ADMIN',
+          },
+        };
       }
 
-      return { success: false, message: 'Invalid credentials' };
+      return {
+        success: false,
+        error: result?.error || result?.message || 'بيانات الدخول غير صحيحة',
+      };
     } catch (error) {
       console.error('Admin Login Error:', error);
       return { success: false, error: error.message };

--- a/frontend/src/lib/auth-service.js
+++ b/frontend/src/lib/auth-service.js
@@ -1,11 +1,9 @@
 /**
  * Auth Service - Authentication System
- * Updated with Emergency Access and Robust Error Handling
- * السوبر أدمن: Bomussa / 14490
+ * Updated with RPC-based authentication and robust error handling
  */
 
 import api from './api-unified';
-import { validateAdminCredentials, ADMIN_CREDENTIALS } from '../config/admin-credentials';
 
 // ✅ إصلاح: تعريف الأدوار والصلاحيات
 export const USER_ROLES = {
@@ -77,50 +75,21 @@ class AuthService {
     console.log('[AuthService] Login attempt:', { username, passwordLength: password?.length });
 
     try {
-      const normalizedUsername = String(username || '').trim().toLowerCase();
-      const normalizedPassword = String(password || '').trim();
+      const response = await api.adminLogin(username, password);
 
-      // ✅ Super Admin fallback: يقبل الأحرف الكبيرة/الصغيرة
-      if (normalizedUsername === 'bomussa' && normalizedPassword === '14490') {
-        console.log('[AuthService] ✅ Super Admin Login - Case-insensitive match');
-        const session = this.createSession(username, 'SUPER_ADMIN');
-        return { success: true, session };
+      if (!response?.success || !response?.data) {
+        throw new Error(response?.error || 'اسم المستخدم أو كلمة المرور غير صحيحة');
       }
 
-      // ✅ Check admin credentials
-      const isValid = validateAdminCredentials(username, password);
-      if (isValid) {
-        console.log('[AuthService] ✅ Admin Login - Credentials valid');
-        const session = this.createSession(username, 'SUPER_ADMIN');
-        return { success: true, session };
-      }
+      const session = this.createSession(
+        response.data.username || response.data.name || username,
+        response.data.role || 'ADMIN'
+      );
 
-      // 2. Try API login for other users
-      try {
-        const controller = new AbortController();
-        const timeoutId = setTimeout(() => controller.abort(), 5000);
-
-        const response = await api.adminLogin(username, password);
-        clearTimeout(timeoutId);
-
-        if (response.success) {
-          const session = this.createSession(username, response.role || 'ADMIN');
-          return { success: true, session };
-        }
-        throw new Error(response.message || response.error || 'Invalid credentials');
-      } catch (apiError) {
-        console.warn('[AuthService] API error:', apiError);
-        throw new Error(apiError.message || 'اسم المستخدم أو كلمة المرور غير صحيحة');
-      }
+      return { success: true, session };
     } catch (error) {
       console.error('[AuthService] Login error:', error);
-      // Fallback for admin credentials on API failure
-      const isValid = validateAdminCredentials(username, password);
-      if (isValid) {
-        const session = this.createSession(username, 'SUPER_ADMIN');
-        return { success: true, session };
-      }
-      throw error;
+      throw new Error(error.message || 'اسم المستخدم أو كلمة المرور غير صحيحة');
     }
   }
 


### PR DESCRIPTION
### Motivation
- Remove an insecure hardcoded admin credential fallback that allowed local login bypasses in the frontend.
- Centralize admin authentication to the backend RPC (`admin_login`) so the server is the single source of truth.
- Standardize the `adminLogin` call shape to a predictable `{ success, data }` / `{ success, error }` contract for simpler and safer client handling.

### Description
- Rewrote `adminLogin` in `frontend/src/lib/api-unified.js` to call `supabase.rpc('admin_login', { p_username, p_password })` and removed the hardcoded `Bomussa/14490` check and local password-hash comparisons.
- Normalized `adminLogin` return values to always use `{ success: true, data: ... }` on success and `{ success: false, error: ... }` on failure.
- Updated `frontend/src/lib/auth-service.js` `login` implementation to depend solely on `api.adminLogin` and to create the client session from `response.data`, removing all local credential fallback logic and the unused `admin-credentials` import.
- Improved error handling so failed RPC responses throw a consistent error message and no local emergency fallbacks are used.

### Testing
- Ran a code search to confirm removed hardcoded fallback strings and local credential checks (no remaining `Bomussa`/`14490`/`validateAdminCredentials` uses found).
- Executed the production build with `npm run build` (which runs `vite build`) and it completed successfully with no build errors.
- No automated unit tests were modified; build-only validation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bfd14533c832aaea975e420622633)