### PR TITLE
Harden `/api/v1/admin/export-secrets` (development-only) and update docs

### DIFF
--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -292,6 +292,10 @@
 #### POST /api/v1/admin/report/export
 **Description:** Export report to R2 (when enabled)
 
+
+> **Security Notice:** `/api/v1/admin/export-secrets` is an internal development-only diagnostic route and is **not available** for client integrations in production or preview environments.
+
+
 ---
 
 ## Features

--- a/lib/api-handlers.js
+++ b/lib/api-handlers.js
@@ -651,11 +651,33 @@ export default async function handler(req, res) {
       return res.status(200).json(formatSuccess({}, 'Patient exited clinic'));
     }
 
-    // ==================== ADMIN: Export Secrets ====================
+    // ==================== ADMIN: Export Secrets (Development Only) ====================
 
     if (pathname === '/api/v1/admin/export-secrets' && method === 'POST') {
+      const requestIp = req.headers['x-forwarded-for'] || req.socket?.remoteAddress || 'unknown';
+      const userAgent = req.headers['user-agent'] || 'unknown';
+
+      // Security audit log for every access attempt.
+      console.warn('[SECURITY] Attempted access to restricted endpoint /api/v1/admin/export-secrets', {
+        method,
+        path: pathname,
+        ip: requestIp,
+        userAgent,
+        environment: process.env.NODE_ENV || 'unknown',
+        timestamp: new Date().toISOString(),
+      });
+
+      if (process.env.NODE_ENV !== 'development') {
+        return res.status(404).json(formatError('Endpoint not found', 'NOT_FOUND'));
+      }
+
       const exportToken = req.headers['x-export-token'];
-      const expectedToken = process.env.EXPORT_TOKEN || 'default-export-token-change-me';
+      const expectedToken = process.env.EXPORT_TOKEN;
+
+      if (!expectedToken) {
+        console.error('[SECURITY] EXPORT_TOKEN is not configured in development mode for /api/v1/admin/export-secrets');
+        return res.status(503).json(formatError('Service unavailable', 'MISCONFIGURED_EXPORT_TOKEN'));
+      }
 
       if (exportToken !== expectedToken) {
         return res.status(401).json(formatError('Unauthorized', 'UNAUTHORIZED'));


### PR DESCRIPTION
### Motivation
- Close a high-risk information exposure by preventing a secrets-enumeration endpoint from being accessible in production or preview environments. 
- Remove a dangerous default fallback token that could allow unauthorized access when `EXPORT_TOKEN` is not set. 
- Improve observability by logging all access attempts to this restricted route for security audits.

### Description
- Restricted `POST /api/v1/admin/export-secrets` to run only when `NODE_ENV === 'development'` and return `404` for other environments to hide the endpoint from clients. 
- Removed the insecure fallback `default-export-token-change-me` and now require `EXPORT_TOKEN` to be explicitly configured; if it is missing in development the endpoint returns `503` with a logged error. 
- Added explicit security audit logging (`console.warn`/`console.error`) for every access attempt including method, path, IP, User-Agent, environment and timestamp. 
- Updated `docs/API_DOCUMENTATION.md` with a `Security Notice` clarifying that `/api/v1/admin/export-secrets` is an internal development-only diagnostic route and must not be used by client integrations.

### Testing
- Ran `node --check lib/api-handlers.js` to validate syntax and it completed successfully.  
- Performed repository searches and diffs to confirm only `lib/api-handlers.js` and `docs/API_DOCUMENTATION.md` were modified and the insecure fallback token was removed.  
- No unit/integration tests were added or modified in this change set (only a syntax check was executed and passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bfd14c9f8832ab0e857f10ac1673e)