### PR TITLE
fix(frontend): align QR session flow to /api/v1/session and add session API client

### DIFF
--- a/frontend/src/components/QrScanPage.jsx
+++ b/frontend/src/components/QrScanPage.jsx
@@ -8,7 +8,7 @@ import React, { useState, useEffect } from 'react'
 import { Camera, Smartphone, Monitor, CheckCircle, XCircle, Loader } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from './Card'
 import { Button } from './Button'
-import axios from 'axios'
+import sessionApiClient from '../lib/session-api-client'
 
 /**
  * كشف نوع الجهاز بدون مكتبات خارجية
@@ -90,15 +90,12 @@ export function QrScanPage({ language = 'ar', toggleLanguage }) {
     setErrorMessage('')
 
     try {
-      const response = await axios.post('/api/session/validate', { token: tokenToValidate })
+      const response = await sessionApiClient.validateToken(tokenToValidate)
 
-      if (response.data?.ok) {
+      if (response?.ok) {
         const detectedDevice = detectDevice()
 
-        await axios.post('/api/session/device', {
-          token: tokenToValidate,
-          device: detectedDevice
-        }).catch(() => {
+        await sessionApiClient.registerDevice(tokenToValidate, detectedDevice).catch(() => {
           // تجاهل أخطاء تسجيل الجهاز - غير حرجة
         })
 

--- a/frontend/src/lib/session-api-client.js
+++ b/frontend/src/lib/session-api-client.js
@@ -1,0 +1,34 @@
+const SESSION_API_BASE = '/api/v1/session';
+
+async function sessionRequest(path, payload) {
+  const response = await fetch(`${SESSION_API_BASE}${path}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-API-Version': 'v1',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  const data = await response.json().catch(() => ({}));
+
+  if (!response.ok) {
+    const error = new Error(data?.error || `HTTP_${response.status}`);
+    error.response = { data, status: response.status };
+    throw error;
+  }
+
+  return data;
+}
+
+export const sessionApiClient = {
+  validateToken(token) {
+    return sessionRequest('/validate', { token });
+  },
+
+  registerDevice(token, device) {
+    return sessionRequest('/device', { token, device });
+  },
+};
+
+export default sessionApiClient;

--- a/frontend/src/lib/session-api-client.test.js
+++ b/frontend/src/lib/session-api-client.test.js
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { sessionApiClient } from './session-api-client';
+
+describe('sessionApiClient', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('calls validate endpoint under /api/v1/session/* contract', async () => {
+    const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true }),
+    });
+
+    const result = await sessionApiClient.validateToken('token-123');
+
+    expect(result).toEqual({ ok: true });
+    expect(fetchSpy).toHaveBeenCalledWith(
+      '/api/v1/session/validate',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          'X-API-Version': 'v1',
+        }),
+        body: JSON.stringify({ token: 'token-123' }),
+      }),
+    );
+  });
+
+  it('throws normalized error when backend returns failure', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({ error: 'SESSION_NOT_FOUND' }),
+    });
+
+    await expect(sessionApiClient.registerDevice('token-123', 'Android')).rejects.toMatchObject({
+      message: 'SESSION_NOT_FOUND',
+      response: {
+        status: 404,
+        data: { error: 'SESSION_NOT_FOUND' },
+      },
+    });
+  });
+});


### PR DESCRIPTION
### Motivation
- The QR scan page used ad-hoc Axios calls to non‑versioned session endpoints which diverged from the backend v1 contract.
- Centralizing session HTTP logic prevents duplicated request handling and makes it easier to change backend contracts in one place.

### Description
- Replaced direct `axios` calls in `frontend/src/components/QrScanPage.jsx` with a unified client import `frontend/src/lib/session-api-client.js` and adjusted response checks to use the client shape (`response?.ok`).
- Added `frontend/src/lib/session-api-client.js` which implements `validateToken` and `registerDevice` against `/api/v1/session/*` and normalizes errors into a consistent shape.
- Added unit tests `frontend/src/lib/session-api-client.test.js` that assert the request contract (URL, headers, body) and normalized error behavior.

### Testing
- Unit tests were added for the new client (`frontend/src/lib/session-api-client.test.js`).
- Attempted to run the tests in this environment, but `vitest` is not installed here so the tests could not be executed (`sh: 1: vitest: not found`).
- No other automated test suites were executed in this workspace.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bfd173cd8832a89fb6dbfa31897d5)