### PR TITLE
Remove patient names from patient queue RPC payloads

### DIFF
--- a/frontend/src/components/PatientPageSafe.jsx
+++ b/frontend/src/components/PatientPageSafe.jsx
@@ -115,7 +115,6 @@ export function PatientPage({ patientData, onLogout, language, toggleLanguage })
   const sessionId = useMemo(() => getSessionId(patientData), [patientData]);
   const queueType = patientData?.queueType || patientData?.examType || 'general';
   const gender = patientData?.gender || 'male';
-  const patientName = patientData?.name || patientData?.patient_name || patientId || sessionId || '';
 
   const getExamName = useCallback(() => {
     const exam = examTypes.find((e) => e.id === queueType);
@@ -140,7 +139,6 @@ export function PatientPage({ patientData, onLogout, language, toggleLanguage })
       const { data, error } = await supabase.rpc('enter_unified_queue_safe', {
         p_clinic_id: station.id,
         p_patient_id: patientId,
-        p_patient_name: patientName,
         p_exam_type: queueType,
         p_gender: gender,
         p_military_id: patientId,
@@ -191,7 +189,7 @@ export function PatientPage({ patientData, onLogout, language, toggleLanguage })
     } finally {
       setLoading(false);
     }
-  }, [gender, language, notify, patientId, patientName, queueType]);
+  }, [gender, language, notify, patientId, queueType]);
 
   const loadPathway = useCallback(async () => {
     if (!patientId) {

--- a/frontend/src/components/PatientPageStable.jsx
+++ b/frontend/src/components/PatientPageStable.jsx
@@ -102,7 +102,6 @@ export function PatientPageStable({ patientData, onLogout, language, toggleLangu
   const sessionId = useMemo(() => getSessionId(patientData), [patientData]);
   const queueType = patientData?.queueType || patientData?.examType || 'general';
   const gender = patientData?.gender || 'male';
-  const patientName = patientData?.name || patientData?.patient_name || patientId || sessionId || '';
 
   const shellStyle = { backgroundColor: 'hsl(var(--background))' };
   const panelStyle = { backgroundColor: 'hsl(var(--card) / 0.82)' };
@@ -137,7 +136,6 @@ export function PatientPageStable({ patientData, onLogout, language, toggleLangu
       const { data, error } = await supabase.rpc('enter_unified_queue_safe', {
         p_clinic_id: station.id,
         p_patient_id: patientId,
-        p_patient_name: patientName,
         p_exam_type: queueType,
         p_gender: gender,
         p_military_id: patientId,
@@ -174,7 +172,7 @@ export function PatientPageStable({ patientData, onLogout, language, toggleLangu
     } finally {
       setLoading(false);
     }
-  }, [gender, language, notify, patientId, patientName, queueType]);
+  }, [gender, language, notify, patientId, queueType]);
 
   const loadPathway = useCallback(async () => {
     if (!patientId) {

--- a/frontend/src/components/PatientPageThemeAware.jsx
+++ b/frontend/src/components/PatientPageThemeAware.jsx
@@ -36,7 +36,6 @@ export function PatientPageThemeAware({ patientData, onLogout, language, toggleL
   const sessionId = useMemo(() => getSessionId(patientData), [patientData]);
   const queueType = patientData?.queueType || patientData?.examType || 'general';
   const gender = patientData?.gender || 'male';
-  const patientName = patientId || sessionId || '';
 
   const [stations, setStations] = useState([]);
   const [initialLoading, setInitialLoading] = useState(true);
@@ -80,7 +79,6 @@ export function PatientPageThemeAware({ patientData, onLogout, language, toggleL
       const { data, error } = await supabase.rpc('enter_unified_queue_safe', {
         p_clinic_id: station.id,
         p_patient_id: patientId,
-        p_patient_name: patientId, // استخدام الرقم العسكري بدلاً من الاسم
         p_exam_type: queueType,
         p_gender: gender,
         p_military_id: patientId,
@@ -102,7 +100,7 @@ export function PatientPageThemeAware({ patientData, onLogout, language, toggleL
     } finally {
       setLoading(false);
     }
-  }, [gender, language, notify, patientId, patientName, queueType]);
+  }, [gender, language, notify, patientId, queueType]);
 
   const loadPathway = useCallback(async () => {
     if (!patientId) {

--- a/supabase/migrations/20260713_remove_patient_name_from_unified_queue_rpc.sql
+++ b/supabase/migrations/20260713_remove_patient_name_from_unified_queue_rpc.sql
@@ -1,0 +1,21 @@
+-- Remove the legacy patient-name argument from the patient queue RPC contract.
+--
+-- The patient-facing React components now call enter_unified_queue_safe with only
+-- non-name patient identifiers and operational fields:
+--   p_clinic_id, p_patient_id, p_exam_type, p_gender,
+--   p_military_id, p_personal_id, and p_force.
+--
+-- If an older database still has the overload that accepts p_patient_name between
+-- p_patient_id and p_exam_type, drop that overload before deploying the frontend.
+-- The active no-name overload must be provided by the backend/love-api migration
+-- that owns the enter_unified_queue_safe implementation.
+DROP FUNCTION IF EXISTS public.enter_unified_queue_safe(
+  TEXT, -- p_clinic_id
+  TEXT, -- p_patient_id
+  TEXT, -- p_patient_name (legacy, removed)
+  TEXT, -- p_exam_type
+  TEXT, -- p_gender
+  TEXT, -- p_military_id
+  TEXT, -- p_personal_id
+  BOOLEAN -- p_force
+);


### PR DESCRIPTION
### Motivation
- Prevent sending patient name PII from the frontend when entering queues and align the UI with a minimal RPC contract that uses identifiers only.
- Ensure the client and backend agree on the `enter_unified_queue_safe` contract so queue operations contain only operational fields and IDs.

### Description
- Removed `patientName` derivation and all uses from `PatientPageThemeAware.jsx`, `PatientPageSafe.jsx`, and `PatientPageStable.jsx` and stopped including `p_patient_name` in `supabase.rpc('enter_unified_queue_safe', ...)` payloads.
- Updated effect dependency arrays to remove `patientName` where applicable so hooks no longer depend on the removed variable.
- Added a Supabase migration SQL task `supabase/migrations/20260713_remove_patient_name_from_unified_queue_rpc.sql` that drops the legacy overload which accepts `p_patient_name`, and documented that the backend must provide the no-name overload before frontend deployment.
- Kept UI display fields (exam/station `.name` / `.nameAr`) untouched and only removed patient-name fallbacks used for RPC payloads.

### Testing
- Verified no remaining `p_patient_name` or `patientName` usages in the patient page components with `rg -n "p_patient_name|patientName|patient_name|\.name" frontend/src/components/PatientPage*.jsx` (remaining matches are legitimate `.name`/`.nameAr` for exam/station labels).
- Built the frontend with `npm run build` and confirmed the build completed successfully (warnings unrelated to this change were observed but the build succeeded).
- Ran `git diff --cached --check` to validate staged changes and committed the modifications.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5478d91648832abdd8f11abd1cc726)