### PR TITLE
Remove patient_name usage and switch VIP/search to ID equality

### DIFF
--- a/frontend/src/components/DoctorControl.jsx
+++ b/frontend/src/components/DoctorControl.jsx
@@ -70,7 +70,7 @@ const DoctorControl = ({ language = 'ar', t = (ar) => ar, doctorId, clinicId }) 
       const { data, error } = await supabase
         .from('unified_queue')
         .select([
-          'id','display_number','patient_name','patient_id',
+          'id','display_number','patient_id',
           'military_id','personal_id','gender','exam_type',
           'status','entered_at','called_at','exam_start_time',
           'exam_end_time','completed_at','entered_clinic_at',
@@ -139,15 +139,25 @@ const DoctorControl = ({ language = 'ar', t = (ar) => ar, doctorId, clinicId }) 
     setVipLoading(true);
     try {
       const today = getQatarDate();
-      // البحث عن المريض في الطابور
-      const { data: found } = await supabase
+      // البحث عن المريض بفلاتر مساواة على أعمدة الهوية القابلة للفهرسة.
+      const vipKey = vipId.trim();
+      const findByIdColumn = async (column) => supabase
         .from('unified_queue')
-        .select('id,display_number,patient_name,status')
+        .select('id,display_number,status')
         .eq('clinic_id', selectedClinic)
         .eq('queue_date', today)
-        .or(`military_id.eq.${vipId.trim()},personal_id.eq.${vipId.trim()},patient_id.eq.${vipId.trim()}`)
+        .eq(column, vipKey)
         .in('status', ['waiting','called'])
+        .order('display_number', { ascending: true })
+        .limit(1)
         .maybeSingle();
+
+      let found = null;
+      for (const column of ['military_id', 'personal_id', 'patient_id']) {
+        const { data, error } = await findByIdColumn(column);
+        if (error) throw error;
+        if (data) { found = data; break; }
+      }
 
       if (found) {
         // تمرير الدور مباشرة
@@ -171,9 +181,8 @@ const DoctorControl = ({ language = 'ar', t = (ar) => ar, doctorId, clinicId }) 
           .from('unified_queue')
           .insert({
             clinic_id: selectedClinic,
-            patient_id: vipId.trim(),
-            personal_id: vipId.trim(),
-            patient_name: `VIP - ${vipId.trim()}`,
+            patient_id: vipKey,
+            personal_id: vipKey,
             status: 'called',
             called_at: getQatarNow(),
             entered_at: getQatarNow(),
@@ -328,9 +337,7 @@ const DoctorControl = ({ language = 'ar', t = (ar) => ar, doctorId, clinicId }) 
   const filtered = patients.filter(p => {
     const idStr  = `${p.patient_id||''} ${p.military_id||''} ${p.personal_id||''}`.toLowerCase();
     const search = searchTerm.toLowerCase();
-    const matchSearch = idStr.includes(search)
-      || (p.patient_name||'').toLowerCase().includes(search)
-      || String(p.display_number||'').includes(search);
+    const matchSearch = idStr.includes(search) || String(p.display_number||'').includes(search);
     let matchStatus = filterStatus === 'all';
     if (!matchStatus) {
       if (filterStatus === 'waiting')     matchStatus = p.status === 'waiting';
@@ -531,7 +538,7 @@ const DoctorControl = ({ language = 'ar', t = (ar) => ar, doctorId, clinicId }) 
         <div className="flex-1 min-w-[200px] relative">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" size={20} />
           <input type="text" value={searchTerm} onChange={e => setSearchTerm(e.target.value)}
-            placeholder={tr('بحث برقم أو اسم المريض...','Search by ID or name...')}
+            placeholder={tr('بحث برقم الهوية أو رقم الدور...','Search by ID or queue number...')}
             className="w-full bg-[#1A1A1A] border border-white/10 rounded-lg pl-10 pr-4 py-3 text-white placeholder-gray-500" />
         </div>
         <select value={filterStatus} onChange={e => setFilterStatus(e.target.value)}

--- a/frontend/src/components/DoctorDashboardFixed.jsx
+++ b/frontend/src/components/DoctorDashboardFixed.jsx
@@ -25,22 +25,19 @@ const pickArray = (snapshot) => {
 const pickValue = (...values) => values.find((value) => value !== undefined && value !== null && value !== '');
 
 const getPatientLabel = (item, index) => {
-  const value = pickValue(
-    item?.patient_name,
-    item?.patientName,
-    item?.name,
-    item?.full_name,
-    item?.fullName,
-    item?.display_name,
-    item?.username,
-    item?.militaryId,
-    item?.military_id,
-    item?.patient_id,
-    item?.patientId,
-    item?.id,
-  );
+  const militaryId = pickValue(item?.military_id, item?.militaryId);
+  const personalId = pickValue(item?.personal_id, item?.personalId);
+  const patientId = pickValue(item?.patient_id, item?.patientId, item?.id);
+  const gender = pickValue(item?.gender, item?.sex);
 
-  return value ? String(value) : `#${index + 1}`;
+  const parts = [
+    militaryId ? `MIL: ${militaryId}` : null,
+    personalId ? `PER: ${personalId}` : null,
+    patientId ? `PID: ${patientId}` : null,
+    gender ? `Gender: ${gender}` : null,
+  ].filter(Boolean);
+
+  return parts.length ? parts.join(' • ') : `#${index + 1}`;
 };
 
 const getQueueStatusBadge = (status) => {
@@ -160,7 +157,7 @@ function DoctorDashboardFixed({ doctorData, onLogout, language = 'ar', toggleLan
   }, [language, refreshStatus]);
 
   const currentQueueId = pickValue(currentPatient?.queueId, currentPatient?.queue_id, currentPatient?.id, currentPatient?.queueID);
-  const currentPatientId = pickValue(currentPatient?.patient_id, currentPatient?.patientId, currentPatient?.personal_id, currentPatient?.militaryId, currentPatient?.military_id, currentPatient?.id);
+  const currentPatientId = pickValue(currentPatient?.patient_id, currentPatient?.patientId, currentPatient?.personal_id, currentPatient?.personalId, currentPatient?.military_id, currentPatient?.militaryId, currentPatient?.id);
   const currentStatus = currentPatient?.status || snapshot?.status || (currentPatient ? 'waiting' : 'idle');
 
   const hasCurrentPatient = Boolean(currentPatient);
@@ -396,7 +393,7 @@ function DoctorDashboardFixed({ doctorData, onLogout, language = 'ar', toggleLan
                 {queue.slice(0, 12).map((item, index) => {
                   const itemStatus = item?.status || 'waiting';
                   const itemLabel = getPatientLabel(item, index);
-                  const itemId = pickValue(item?.patient_id, item?.patientId, item?.militaryId, item?.military_id, item?.id);
+                  const itemId = pickValue(item?.patient_id, item?.patientId, item?.military_id, item?.militaryId, item?.personal_id, item?.personalId, item?.id);
                   const itemNumber = pickValue(item?.display_number, item?.displayNumber, item?.queue_number, item?.queueNumber, item?.number);
 
                   return (


### PR DESCRIPTION
### Motivation

- Stop using `patient_name`/`patientName` for identity resolution and display to avoid relying on free-text name fields and to present stable indexed identifiers instead.  
- Replace text-based searches and synthetic VIP name payloads with equality filters on ID columns so lookups use indexed columns for predictable performance.  
- Keep VIP & priority semantics while removing ad-hoc `VIP - ...` name insertion so schema flags (`is_vip`, `is_priority`) represent priority state.

### Description

- Updated `getPatientLabel` in `frontend/src/components/DoctorDashboardFixed.jsx` to build the visible label from `military_id`, `personal_id`, `patient_id` (and the `gender`) only, removing all `patient_name`/`patientName`/name fallbacks.  
- Adjusted `currentPatientId` and `itemId` fallbacks to prioritize explicit ID columns (including `personalId`/`personal_id` and `militaryId`/`military_id`) and removed name-based fallbacks.  
- Removed `patient_name` from the `select()` call in `frontend/src/components/DoctorControl.jsx` and changed the local `filtered` predicate to match only `patient_id`, `military_id`, `personal_id`, and `display_number` instead of `(p.patient_name||'').toLowerCase().includes(search)`.  
- Reworked `callVipPatient` to search for existing patients by iterating equality queries on `military_id`, `personal_id`, and `patient_id` (indexed equality filters), and removed the `patient_name: \\`VIP - ${vipId.trim()}\\`` insert payload while keeping `is_vip`/`is_priority` flags on updates/inserts.

### Testing

- Ran the search for remaining occurrences with `rg -n "patient_name|patientName|VIP -" frontend/src/components/DoctorDashboardFixed.jsx frontend/src/components/DoctorControl.jsx` and verified the targeted files no longer contain those patterns. (succeeded)  
- Built the frontend with `npm run build` and confirmed the production build completed without errors. (succeeded)  
- Executed the repository check `cd frontend && npm run check:no-conflict-files` to validate no forbidden conflict/backup files are present. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5478dfe224832a954f740737954e06)