### PR TITLE
Virtualize heavy admin lists with @tanstack/react-virtual

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@hookform/resolvers": "^5.0.1",
         "@radix-ui/react-accordion": "^1.2.8",
@@ -37,6 +37,7 @@
         "@radix-ui/react-toggle-group": "^1.1.7",
         "@radix-ui/react-tooltip": "^1.2.4",
         "@supabase/supabase-js": "^2.95.3",
+        "@tanstack/react-virtual": "^3.14.6",
         "@vercel/analytics": "^1.6.1",
         "@vercel/speed-insights": "^1.3.1",
         "@vitejs/plugin-react": "^5.1.0",
@@ -4960,6 +4961,33 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.6.tgz",
+      "integrity": "sha512-4+Uq8m0/gzO4kMCHUEpTtGX1RnONK0C+g88b2ltwPMWUBiaVarBuWKoPJaz7gj1cKCVRAdyu+U8GcKhwCc2beA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.4"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.4.tgz",
+      "integrity": "sha512-nGm5KteqxasUdThLc2izl6dHUqLv0LQj7Nuyo5gYalTPf/U8a9ermvsl7reT+6ioBW1l8WfpP/mcU338nLXpqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@types/babel__core": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,7 @@
     "@radix-ui/react-toggle-group": "^1.1.7",
     "@radix-ui/react-tooltip": "^1.2.4",
     "@supabase/supabase-js": "^2.95.3",
+    "@tanstack/react-virtual": "^3.14.6",
     "@vercel/analytics": "^1.6.1",
     "@vercel/speed-insights": "^1.3.1",
     "@vitejs/plugin-react": "^5.1.0",

--- a/frontend/src/components/AdminDashboardV2.jsx
+++ b/frontend/src/components/AdminDashboardV2.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import authService, { USER_ROLES } from '../lib/auth-service';
 import toast, { Toaster } from 'react-hot-toast';
 
@@ -13,6 +14,65 @@ import {
   UserCog, History, Database, Save, Upload, Wifi, WifiOff, Lock, Unlock, Copy, Share2,
   UserPlus, Zap, FolderOpen, Stethoscope, UserX, AlertTriangle, Star, ArrowRight, ArrowLeft
 } from 'lucide-react';
+
+
+const VirtualizedList = ({
+  items,
+  estimateSize = 72,
+  maxHeight = 500,
+  className = '',
+  renderItem,
+  getKey = (item, index) => item?.id || index
+}) => {
+  const parentRef = React.useRef(null);
+  const rowVirtualizer = useVirtualizer({
+    count: items.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => estimateSize,
+    overscan: 6
+  });
+
+  return (
+    <div ref={parentRef} className="overflow-y-auto" style={{ maxHeight }}>
+      <div className={className} style={{ height: `${rowVirtualizer.getTotalSize()}px`, position: 'relative' }}>
+        {rowVirtualizer.getVirtualItems().map(virtualRow => {
+          const item = items[virtualRow.index];
+          return (
+            <div
+              key={getKey(item, virtualRow.index)}
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                transform: `translateY(${virtualRow.start}px)`
+              }}
+            >
+              {renderItem(item, virtualRow.index)}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+const useVirtualTable = (items, estimateSize = 56) => {
+  const parentRef = React.useRef(null);
+  const rowVirtualizer = useVirtualizer({
+    count: items.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => estimateSize,
+    overscan: 8
+  });
+  const virtualRows = rowVirtualizer.getVirtualItems();
+  const paddingTop = virtualRows.length > 0 ? virtualRows[0].start : 0;
+  const paddingBottom = virtualRows.length > 0
+    ? rowVirtualizer.getTotalSize() - virtualRows[virtualRows.length - 1].end
+    : 0;
+
+  return { parentRef, virtualRows, paddingTop, paddingBottom };
+};
 
 // دالة عرض شعار النجاح
 const showSuccessToast = (message) => {
@@ -4055,6 +4115,7 @@ const UsersManagement = ({ language, t }) => {
     'ADMIN': 'bg-blue-500',
     'STAFF': 'bg-green-500'
   };
+  const usersVirtualTable = useVirtualTable(users, 64);
 
   return (
     <div className="space-y-6">
@@ -4073,8 +4134,9 @@ const UsersManagement = ({ language, t }) => {
 
       {/* جدول المستخدمين */}
       <div className="bg-gradient-to-br from-[#8A1538] to-[#6B0F2A] rounded-2xl border border-white/10 overflow-hidden">
+        <div ref={usersVirtualTable.parentRef} className="max-h-[520px] overflow-auto">
         <table className="w-full">
-          <thead className="bg-black/20">
+          <thead className="bg-black/20 sticky top-0 z-10">
             <tr>
               <th className="px-4 py-3 text-right text-sm font-medium text-gray-300">{t('اسم المستخدم', 'Username')}</th>
               <th className="px-4 py-3 text-right text-sm font-medium text-gray-300">{t('الصلاحية', 'Role')}</th>
@@ -4084,7 +4146,10 @@ const UsersManagement = ({ language, t }) => {
             </tr>
           </thead>
           <tbody className="divide-y divide-white/5">
-            {users.map(user => (
+            {usersVirtualTable.paddingTop > 0 && <tr><td colSpan={5} style={{ height: usersVirtualTable.paddingTop }} /></tr>}
+            {usersVirtualTable.virtualRows.map(virtualRow => {
+              const user = users[virtualRow.index];
+              return (
               <tr key={user.id} className="hover:bg-white/5">
                 <td className="px-4 py-3 font-medium">{user.username}</td>
                 <td className="px-4 py-3">
@@ -4130,9 +4195,12 @@ const UsersManagement = ({ language, t }) => {
                   </div>
                 </td>
               </tr>
-            ))}
+              );
+            })}
+            {usersVirtualTable.paddingBottom > 0 && <tr><td colSpan={5} style={{ height: usersVirtualTable.paddingBottom }} /></tr>}
           </tbody>
         </table>
+        </div>
       </div>
 
       {/* Modal إضافة مستخدم */}
@@ -4414,14 +4482,18 @@ const ActivityLog = ({ language, t }) => {
       </div>
 
       <div className="bg-gradient-to-br from-[#8A1538] to-[#6B0F2A] rounded-2xl border border-white/10 overflow-hidden">
-        <div className="max-h-[500px] overflow-y-auto">
+        <div>
           {logs.length === 0 ? (
             <div className="p-8 text-center text-gray-400">
               {t('لا توجد سجلات', 'No logs found')}
             </div>
           ) : (
-            <div className="divide-y divide-white/5">
-              {logs.map(log => (
+            <VirtualizedList
+              items={logs}
+              estimateSize={72}
+              maxHeight={500}
+              className="divide-y divide-white/5"
+              renderItem={(log) => (
                 <div key={log.id} className="p-4 hover:bg-white/5 flex items-center gap-4">
                   <div className="p-2 bg-white/10 rounded-lg">
                     {actionIcons[log.action_type] || <Activity size={16} />}
@@ -4434,8 +4506,8 @@ const ActivityLog = ({ language, t }) => {
                     {new Date(log.created_at).toLocaleString('ar-QA')}
                   </div>
                 </div>
-              ))}
-            </div>
+              )}
+            />
           )}
         </div>
       </div>
@@ -5442,6 +5514,8 @@ const DatabaseManagement = ({ language, t }) => {
     }
   };
 
+  const tableDataVirtualTable = useVirtualTable(tableData, 56);
+
   const exportTable = () => {
     const json = JSON.stringify(tableData, null, 2);
     const blob = new Blob([json], { type: 'application/json' });
@@ -5508,9 +5582,9 @@ const DatabaseManagement = ({ language, t }) => {
               {t('لا توجد بيانات', 'No data found')}
             </div>
           ) : (
-            <div className="overflow-x-auto">
+            <div ref={tableDataVirtualTable.parentRef} className="max-h-[560px] overflow-auto">
               <table className="w-full">
-                <thead className="bg-white/5">
+                <thead className="bg-white/5 sticky top-0 z-10">
                   <tr>
                     {Object.keys(tableData[0]).slice(0, 6).map(key => (
                       <th key={key} className="px-4 py-3 text-left text-sm font-medium text-gray-300">
@@ -5523,7 +5597,11 @@ const DatabaseManagement = ({ language, t }) => {
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-white/5">
-                  {tableData.map((row, index) => (
+                  {tableDataVirtualTable.paddingTop > 0 && <tr><td colSpan={7} style={{ height: tableDataVirtualTable.paddingTop }} /></tr>}
+                  {tableDataVirtualTable.virtualRows.map((virtualRow) => {
+                    const row = tableData[virtualRow.index];
+                    const index = virtualRow.index;
+                    return (
                     <tr key={row.id || index} className="hover:bg-white/5">
                       {Object.entries(row).slice(0, 6).map(([key, value]) => (
                         <td key={key} className="px-4 py-3 text-sm">
@@ -5577,7 +5655,9 @@ const DatabaseManagement = ({ language, t }) => {
                         </div>
                       </td>
                     </tr>
-                  ))}
+                    );
+                  })}
+                  {tableDataVirtualTable.paddingBottom > 0 && <tr><td colSpan={7} style={{ height: tableDataVirtualTable.paddingBottom }} /></tr>}
                 </tbody>
               </table>
             </div>
@@ -5758,8 +5838,12 @@ const SmartSystemPanel = ({ language, t }) => {
           <h3 className="text-lg font-bold text-white mb-4 flex items-center gap-2">
             <History size={18} className="text-indigo-400" /> {t('آخر عمليات الفحص', 'Recent Runs')}
           </h3>
-          <div className="space-y-3">
-            {qaRuns.map(run => (
+          <VirtualizedList
+            items={qaRuns}
+            estimateSize={76}
+            maxHeight={420}
+            className="space-y-3"
+            renderItem={(run) => (
               <div key={run.id} className="p-3 bg-white/5 border border-white/5 rounded-xl flex justify-between items-center">
                 <div>
                   <div className="text-sm font-medium text-white">
@@ -5771,8 +5855,8 @@ const SmartSystemPanel = ({ language, t }) => {
                   {run.ok ? t('سليم', 'Healthy') : t('به مشاكل', 'Issues')}
                 </div>
               </div>
-            ))}
-          </div>
+            )}
+          />
         </div>
 
         {/* Findings & Auto-Repair */}
@@ -5786,7 +5870,12 @@ const SmartSystemPanel = ({ language, t }) => {
                 {t('لا توجد مشاكل حالية، النظام يعمل بكفاءة 100%', 'No issues found, system running at 100%')}
               </div>
             )}
-            {findings.map(finding => (
+            <VirtualizedList
+              items={findings}
+              estimateSize={132}
+              maxHeight={560}
+              className="space-y-4"
+              renderItem={(finding) => (
               <div key={finding.id} className="p-4 bg-white/5 border border-white/5 rounded-xl flex flex-col md:flex-row justify-between gap-4">
                 <div className="flex gap-4">
                   <div className={`p-3 rounded-xl h-fit ${finding.severity === 'critical' ? 'bg-red-500/20 text-red-400' : 'bg-amber-500/20 text-amber-400'}`}>
@@ -5818,7 +5907,8 @@ const SmartSystemPanel = ({ language, t }) => {
                   )}
                 </div>
               </div>
-            ))}
+              )}
+            />
           </div>
         </div>
       </div>


### PR DESCRIPTION
### Motivation
- Reduce frontend rendering cost and memory usage for large admin lists/tables by virtualizing DOM nodes.
- Target the highest-risk renderers (users list, activity logs, database table view, QA runs, findings) while keeping visual styling and interaction unchanged.
- Keep server-side paging/range logic in place so virtualization only reduces client DOM, not backend data volume.

### Description
- Added dependency `@tanstack/react-virtual` to `frontend/package.json` and installed its lockfile entries.
- Introduced `VirtualizedList` and `useVirtualTable` helpers inside `frontend/src/components/AdminDashboardV2.jsx` and imported `useVirtualizer` for virtualization.
- Replaced direct `.map()` rendering for admin users, activity logs, database `tableData`, QA `qaRuns`, and `findings` with virtualized renderers that preserve existing Tailwind classes, table/card markup, and sticky headers where applicable.
- Preserved existing Supabase query limits and server-side behavior (`.limit()`, `.range()`/RPC usage unchanged) so backend pagination remains the source of truth.

### Testing
- Ran `npm install` to add the new dependency successfully (lockfile updated). — succeeded.
- Ran `npm run build` (Vite production build); build completed successfully but emitted pre-existing warnings about the missing `%VITE_SUPABASE_URL%` env placeholder and some CSS selector syntax warnings; these are unchanged by this PR. — succeeded with warnings.
- Ran `npm run check:no-conflict-files` to ensure no forbidden backup/conflict files under `src`. — succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5478e4ec44832ab98963538c64195a)