### PR TITLE
Document frontend source authority and add duplicate-components CI guard

### DIFF
--- a/.github/workflows/duplicate-components.yml
+++ b/.github/workflows/duplicate-components.yml
@@ -1,0 +1,23 @@
+name: Duplicate active component guard
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  duplicate-components:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Fail on duplicate active component paths
+        run: npm run check:duplicate-components

--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ The live application code is centered in:
 - `frontend/src/lib/api.js` — `/api/v1` compatibility contract
 - `frontend/src/lib/local-api.js` — legacy fallback path only
 
+
+## Frontend source authority
+
+The root `package.json` `build` script is the build source of truth for this repository. It runs the Vite production build from `frontend` (`cd frontend && ... vite build`), synchronizes runtime configuration there, and then copies `frontend/dist` back to the repository-level `dist` directory for deployment. The Vercel configuration also invokes `npm run build`, so production deployments follow this same path.
+
+Because the production build executes from `frontend`, `frontend/src` is the authoritative frontend source tree. Treat files under the repository-level `src` directory as legacy or server/compatibility code unless a deployment configuration explicitly proves they are active. Do not make production UI fixes only in root `src/components`; migrate any needed changes into `frontend/src/components`.
+
+Before archiving or deleting any duplicated component, compare the legacy and active copies with `diff -u src/path frontend/src/path`, migrate any missing production fixes into `frontend/src`, and perform that cleanup in a dedicated verified cleanup PR. CI runs `npm run check:duplicate-components` to fail when the same component path exists in both `src/components` and `frontend/src/components`.
+
 ## Active journeys
 
 ### Patient journey

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test:final": "node final-integration-test.js",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
-    "verify:ui": "npm run build"
+    "verify:ui": "npm run build",
+    "check:duplicate-components": "node scripts/check-duplicate-active-components.mjs"
   },
   "engines": {
     "node": ">=18.17 <21"

--- a/scripts/check-duplicate-active-components.mjs
+++ b/scripts/check-duplicate-active-components.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+import { existsSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const legacyDir = path.join(root, 'src', 'components');
+const activeDir = path.join(root, 'frontend', 'src', 'components');
+
+function collectFiles(dir, prefix = '') {
+  if (!existsSync(dir)) return [];
+  const entries = readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name));
+  const files = [];
+  for (const entry of entries) {
+    const relative = path.join(prefix, entry.name);
+    const absolute = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectFiles(absolute, relative));
+    } else if (entry.isFile()) {
+      files.push(relative.split(path.sep).join('/'));
+    }
+  }
+  return files;
+}
+
+const legacyFiles = new Set(collectFiles(legacyDir));
+const activeFiles = new Set(collectFiles(activeDir));
+const duplicates = [...legacyFiles].filter((file) => activeFiles.has(file)).sort();
+
+if (duplicates.length === 0) {
+  console.log('No duplicate active component paths found between src/components and frontend/src/components.');
+  process.exit(0);
+}
+
+console.error('Duplicate active component paths found between src/components and frontend/src/components.');
+console.error('frontend/src is the authoritative frontend source; root src/components must not carry active duplicates.');
+console.error('Before archiving or deleting any duplicate, compare and migrate production fixes with:');
+for (const file of duplicates) {
+  const legacyPath = path.posix.join('src/components', file);
+  const activePath = path.posix.join('frontend/src/components', file);
+  console.error(`  diff -u ${legacyPath} ${activePath}`);
+}
+console.error(`\nDuplicate count: ${duplicates.length}`);
+process.exit(1);


### PR DESCRIPTION
### Motivation
- Make it explicit that the production build runs from `frontend` and that `frontend/src` is the authoritative frontend source tree. 
- Prevent accidental divergence by failing CI when the same component path exists in both `src/components` and `frontend/src/components` so cleanup is deliberate and verified. 

### Description
- Add a `Frontend source authority` section to `README.md` documenting that the root `build` script runs `cd frontend && ... vite build` and that `frontend/src` is the authoritative UI code. 
- Add a new guard script at `scripts/check-duplicate-active-components.mjs` that enumerates files under `src/components` and `frontend/src/components`, emits `diff -u src/path frontend/src/path` for duplicates, and exits non‑zero when duplicates exist. 
- Publish the guard via a new npm script `check:duplicate-components` in `package.json`. 
- Add a GitHub Actions workflow `.github/workflows/duplicate-components.yml` to run the guard on `pull_request` and on pushes to `main`/`master`. 

### Testing
- Ran `npm run build` (root build which runs the `frontend` build); the build completed successfully but reported existing dependency audit findings and existing Vite env/CSS warnings. 
- Ran `npm run check:duplicate-components` and the guard correctly detected duplicate component paths and exited non‑zero, listing `diff -u` commands for each duplicate (duplicate count: 16), demonstrating the CI check will block merges until duplicates are resolved. 
- The new workflow and script were committed and exercised locally; no other automated tests were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5478e62600832a8722958565018826)