### PR TITLE
Add secret scanning workflow and incident response runbook

### DIFF
--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -1,0 +1,28 @@
+name: Secret Scanning
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  gitleaks:
+    name: Gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Scan for committed secrets
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/secret-incident-response.md
+++ b/docs/secret-incident-response.md
@@ -1,0 +1,26 @@
+# Secret Exposure Incident Response
+
+This runbook documents the required manual response when a GitHub token, Vercel token, Supabase key, or JWT signing secret is exposed. Do not store replacement secrets in this repository.
+
+## Immediate revocation and rotation
+
+1. Revoke exposed GitHub personal access tokens in GitHub Developer Settings.
+2. Revoke exposed Vercel API tokens in the Vercel account or team settings.
+3. Rotate Supabase `service_role` and `anon` keys in the Supabase project API settings.
+4. Rotate the backend/session JWT signing secret and redeploy all services that verify sessions.
+5. Update Vercel, Supabase, and GitHub environment variables only through provider dashboards or approved secret managers.
+
+## Access review
+
+After revocation, audit provider logs for unexpected activity from the exposure window onward:
+
+- GitHub: security log, repository audit log, token usage metadata, Actions runs, deployments, branch protection changes, and collaborator changes.
+- Vercel: team audit log, deployment history, environment variable changes, domain changes, integrations, and token activity where available.
+- Supabase: project audit logs, API logs, auth logs, database logs, edge function logs, and configuration changes.
+
+## Preventive controls
+
+- Keep GitHub Advanced Security secret scanning and push protection enabled for both `love` and `love-api` when available for the account plan.
+- Keep the repository CI secret scan workflow enabled for pull requests and protected branch pushes.
+- Never paste production secrets into issues, pull requests, commits, logs, chat transcripts, or generated reports.
+- Prefer short-lived tokens and least-privilege scopes for automation.


### PR DESCRIPTION
### Motivation

- Introduce automated detection for accidentally committed secrets to reduce the risk of leaked credentials.  
- Provide an actionable, documented incident response runbook so operators know the immediate revocation and rotation steps without storing secrets in the repo.

### Description

- Add a GitHub Actions workflow at `.github/workflows/secret-scanning.yml` that runs `gitleaks/gitleaks-action@v2` on `pull_request`, pushes to `main`/`master`, and manual dispatches, with repository read-only permissions.  
- Add `docs/secret-incident-response.md` containing step-by-step manual revocation/rotation guidance for GitHub, Vercel, Supabase, and JWT secrets and guidance for auditing provider logs.  
- The workflow checks out the repository with full history (`fetch-depth: 0`) and uses the `GITHUB_TOKEN` environment variable for the scan step.

### Testing

- Ran `git diff --check -- .github/workflows/secret-scanning.yml docs/secret-incident-response.md` to validate file formatting, which completed successfully.  
- Ran a repository grep for common secret patterns using `rg -n "github_pat_[A-Za-z0-9_]+|sbp_[A-Za-z0-9]+|eyJ[A-Za-z0-9_.-]+|[A-Za-z0-9_-]{32,}\.[A-Za-z0-9_-]{32,}\.[A-Za-z0-9_-]{32,}" .github/workflows/secret-scanning.yml docs/secret-incident-response.md || true` which returned no accidental secrets in the added files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5478ea654c832a850203b2deb8970c)