### PR TITLE
fix: canonical weighted routes and realtime patient synchronization

### DIFF
--- a/.github/workflows/production-ui-acceptance.yml
+++ b/.github/workflows/production-ui-acceptance.yml
@@ -74,7 +74,7 @@ jobs:
             "$E2E_BASE_URL/api/v1/ci/session" \
             -o "$E2E_ACCEPTANCE_FILE"
 
-          jq -e '.success == true and .data.admin.token and (.data.doctors | length > 0) and (.data.patientIds | length == 3)' \
+          jq -e '.success == true and .data.admin.token and (.data.doctors | length > 0) and (.data.patientIds | length == 4)' \
             "$E2E_ACCEPTANCE_FILE" >/dev/null
 
           while IFS= read -r secret; do
@@ -86,6 +86,54 @@ jobs:
 
       - name: Run complete browser acceptance
         run: npx playwright test --config=playwright.production.config.js
+
+      - name: Verify persisted queues, records, events and statistics
+        shell: bash
+        run: |
+          set -euo pipefail
+          oidc_response=$(curl -fsSL \
+            -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${OIDC_AUDIENCE}")
+          oidc_token=$(jq -er '.value' <<<"$oidc_response")
+          echo "::add-mask::$oidc_token"
+
+          verify_response=$(curl -fsSL \
+            -X POST \
+            -H "Authorization: Bearer $oidc_token" \
+            -H 'Content-Type: application/json' \
+            --data '{"action":"verify"}' \
+            "$E2E_BASE_URL/api/v1/ci/session")
+
+          jq -e '
+            .success == true
+            and .data.healthy == true
+            and .data.journeys == 4
+            and .data.completed_journeys == 4
+            and .data.total_stations > 0
+            and .data.route_rows == .data.total_stations
+            and .data.called_events == .data.total_stations
+            and .data.completed_events == .data.total_stations
+            and .data.session_called == .data.total_stations
+            and .data.session_completed == .data.total_stations
+            and .data.completed_exam_records == 4
+          ' <<<"$verify_response" >/dev/null
+
+          printf '%s\n' "$verify_response" | jq '{
+            success,
+            data: {
+              healthy,
+              journeys,
+              completed_journeys,
+              total_stations,
+              route_rows,
+              called_events,
+              completed_events,
+              session_called,
+              session_completed,
+              completed_exam_records,
+              details
+            }
+          }'
 
       - name: Cleanup isolated acceptance data
         if: always() && steps.bootstrap.outcome == 'success'

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,7 +5,6 @@ import { SpeedInsights } from '@vercel/speed-insights/react';
 import { Analytics } from '@vercel/analytics/react';
 import api from './lib/api-unified';
 import authService from './lib/auth-service';
-import getDynamicMedicalPathway from './lib/dynamic-pathways';
 import { enhancedMedicalThemes, generateThemeCSS } from './lib/enhanced-themes';
 import { getCurrentLanguage, setCurrentLanguage } from './lib/i18n';
 
@@ -383,9 +382,6 @@ function App() {
 
   const handleExamSelect = async (examType) => {
     try {
-      const clinics = await getDynamicMedicalPathway(examType, patientData?.gender || 'male');
-      if (!clinics || clinics.length === 0) throw new Error(`No clinics found for: ${examType}`);
-
       const patientId = String(
         patientData?.patient_id
         || patientData?.patientId
@@ -397,22 +393,33 @@ function App() {
       ).trim();
       if (!patientId) throw new Error('PATIENT_ID_MISSING');
 
-      const firstClinic = clinics[0];
-      const routeResult = await api.createRoute(
-        patientId,
-        examType,
-        patientData?.gender || 'male',
-        clinics,
-      );
+      const gender = patientData?.gender || 'male';
+      const routeResult = await api.createRoute(patientId, examType, gender);
       if (routeResult?.success === false) throw new Error(routeResult.error || 'ROUTE_CREATE_FAILED');
 
+      const canonicalRoute = routeResult?.route || routeResult?.data?.route || routeResult?.data || routeResult;
+      const clinics = Array.isArray(canonicalRoute?.stations)
+        ? canonicalRoute.stations
+        : Array.isArray(canonicalRoute?.pathway)
+          ? canonicalRoute.pathway
+          : [];
+      if (!clinics.length) throw new Error('CANONICAL_ROUTE_EMPTY');
+
+      const currentStep = Math.max(0, Math.min(
+        Number(canonicalRoute?.current_station_index ?? canonicalRoute?.current_step ?? 0),
+        clinics.length - 1,
+      ));
+      const currentClinic = clinics[currentStep]
+        || clinics.find((clinic) => String(clinic?.status || '').toLowerCase() === 'ready')
+        || clinics[0];
+
       const enterResult = await api.enterQueue(
-        firstClinic.id,
+        currentClinic.id,
         patientId,
         false,
         null,
         examType,
-        patientData?.gender || 'male',
+        gender,
         patientData?.military_id || patientData?.militaryId || null,
         patientData?.personal_id || patientData?.personalId || patientId,
       );
@@ -422,10 +429,11 @@ function App() {
         ...patientData,
         queueType: examType,
         examType,
-        currentClinic: firstClinic.id,
+        currentClinic: currentClinic.id,
         pathway: clinics,
-        queueNumber: enterResult?.display_number || null,
-        queueId: enterResult?.id || null,
+        route: canonicalRoute,
+        queueNumber: enterResult?.display_number || canonicalRoute?.display_number || null,
+        queueId: enterResult?.id || enterResult?.queue_id || canonicalRoute?.queue_id || canonicalRoute?.id || null,
       };
 
       setPatientData(updatedData);

--- a/frontend/src/components/PatientPageThemeAware.jsx
+++ b/frontend/src/components/PatientPageThemeAware.jsx
@@ -19,6 +19,41 @@ const normalize = (status) => {
 const getPatientId = (p) => String(p?.patient_id || p?.personal_id || p?.patientId || p?.personalId || p?.id || '').trim();
 const template = (stations) => stations.map((s, i) => ({ ...s, status: i === 0 ? 'ready' : 'locked', isEntered: false, yourNumber: null, ahead: null, current: null, totalWaiting: null, entered_at: null }));
 
+function extractCanonicalRoute(response) {
+  return response?.route || response?.data?.route || response?.data || response || null;
+}
+
+function canonicalRouteStations(route) {
+  if (Array.isArray(route?.stations)) return route.stations;
+  if (Array.isArray(route?.pathway)) return route.pathway;
+  if (Array.isArray(route?.path)) return route.path;
+  return [];
+}
+
+function prepareCanonicalStations(route) {
+  const source = canonicalRouteStations(route);
+  const rawStep = Number(route?.current_station_index ?? route?.current_step ?? 0);
+  const currentStep = Math.max(0, Math.min(Number.isFinite(rawStep) ? rawStep : 0, source.length));
+  const complete = Boolean(route?.completed)
+    || ['completed', 'done'].includes(String(route?.status || '').toLowerCase())
+    || currentStep >= source.length;
+  const queueId = route?.queue_id || route?.id || null;
+
+  return source.map((station, index) => ({
+    ...station,
+    nameAr: station.nameAr || station.name_ar || station.name || station.id,
+    name: station.nameEn || station.name_en || station.name || station.nameAr || station.id,
+    queueId,
+    status: complete || index < currentStep ? 'completed' : index === currentStep ? 'ready' : 'locked',
+    isEntered: false,
+    yourNumber: null,
+    ahead: null,
+    current: null,
+    totalWaiting: null,
+    entered_at: null,
+  }));
+}
+
 async function queuePosition(clinicId, patientId) {
   const response = await api.getQueuePosition(clinicId, patientId);
   if (!response?.success) return null;
@@ -43,6 +78,9 @@ export function PatientPageThemeAware({ patientData, onLogout, language, toggleL
   const [loading, setLoading] = useState(false);
   const [currentNotice, setCurrentNotice] = useState(null);
   const [directAlerts, setDirectAlerts] = useState([]);
+  const [routeVersion, setRouteVersion] = useState(0);
+  const [lastSyncAt, setLastSyncAt] = useState(null);
+  const [realtimeStatus, setRealtimeStatus] = useState('IDLE');
   const channelRef = useRef(null);
   const pollTimerRef = useRef(null);
   const noticeTimerRef = useRef(null);
@@ -115,6 +153,63 @@ export function PatientPageThemeAware({ patientData, onLogout, language, toggleL
     }
   }, [gender, language, notify, patientId, queueType]);
 
+  const refreshJourney = useCallback(async ({ enterIfMissing = false } = {}) => {
+    let response = await api.getRoute(patientId);
+    let route = response?.success === false ? null : extractCanonicalRoute(response);
+    let routeStations = canonicalRouteStations(route);
+
+    if (!route || routeStations.length === 0) {
+      let fallback = Array.isArray(patientData?.route?.stations) && patientData.route.stations.length > 0
+        ? patientData.route.stations
+        : Array.isArray(patientData?.pathway) && patientData.pathway.length > 0
+          ? patientData.pathway
+          : await getDynamicMedicalPathway(queueType, gender);
+      if (!Array.isArray(fallback) || fallback.length === 0) throw new Error('EMPTY_PATHWAY');
+
+      response = await api.createRoute(patientId, queueType, gender, fallback);
+      if (response?.success === false) throw new Error(response?.error || 'ROUTE_PERSISTENCE_FAILED');
+      route = extractCanonicalRoute(response);
+      routeStations = canonicalRouteStations(route);
+    }
+
+    const prepared = prepareCanonicalStations(route);
+    if (!prepared.length) throw new Error('CANONICAL_ROUTE_EMPTY');
+
+    const rawStep = Number(route?.current_station_index ?? route?.current_step ?? 0);
+    const currentStep = Math.max(0, Math.min(Number.isFinite(rawStep) ? rawStep : 0, prepared.length));
+    const complete = Boolean(route?.completed)
+      || ['completed', 'done'].includes(String(route?.status || '').toLowerCase())
+      || currentStep >= prepared.length;
+
+    setRouteVersion(Number(route?.version || 0));
+    setLastSyncAt(Date.now());
+
+    if (complete) {
+      setStations(prepared.map((station) => ({ ...station, status: 'completed', isEntered: false })));
+      return route;
+    }
+
+    const currentStation = prepared[currentStep];
+    const position = await queuePosition(currentStation.id, patientId);
+    if (position) {
+      prepared[currentStep] = {
+        ...currentStation,
+        queueId: position.id || currentStation.queueId,
+        yourNumber: position.display_number,
+        current: position.current_number,
+        ahead: position.ahead,
+        totalWaiting: position.total_waiting,
+        status: 'ready',
+        isEntered: true,
+        entered_at: position.entered_at,
+      };
+    }
+
+    setStations(prepared);
+    if (!position && enterIfMissing) await enterStation(currentStation, currentStep);
+    return route;
+  }, [enterStation, gender, patientData, patientId, queueType]);
+
   const loadPathway = useCallback(async () => {
     if (!patientId) {
       setInitialLoading(false);
@@ -124,60 +219,19 @@ export function PatientPageThemeAware({ patientData, onLogout, language, toggleL
 
     setInitialLoading(true);
     setPathwayError(null);
-
     try {
-      let pathway = Array.isArray(patientData?.pathway) && patientData.pathway.length > 0 ? patientData.pathway : null;
-      if (!pathway && Array.isArray(patientData?.route?.stations) && patientData.route.stations.length > 0) {
-        pathway = patientData.route.stations;
-      }
-
-      const saved = await api.getRoute(patientId);
-      const savedStations = saved?.success && Array.isArray(saved?.route?.stations) && saved.route.stations.length > 0
-        ? saved.route.stations
-        : null;
-
-      if (!pathway && savedStations) pathway = savedStations;
-      if (!pathway) pathway = await getDynamicMedicalPathway(queueType, gender);
-      if (!Array.isArray(pathway) || pathway.length === 0) throw new Error('EMPTY_PATHWAY');
-
-      const prepared = template(pathway);
-      const firstPosition = await queuePosition(prepared[0].id, patientId);
-
-      if (firstPosition) {
-        prepared[0] = {
-          ...prepared[0],
-          queueId: firstPosition.id,
-          yourNumber: firstPosition.display_number,
-          current: firstPosition.current_number,
-          ahead: firstPosition.ahead,
-          totalWaiting: firstPosition.total_waiting,
-          status: normalize(firstPosition.status) === 'completed' ? 'completed' : 'ready',
-          isEntered: normalize(firstPosition.status) !== 'completed',
-          entered_at: firstPosition.entered_at,
-        };
-        setStations(prepared);
-        return;
-      }
-
-      if (!savedStations) {
-        const routeResult = await api.createRoute(patientId, queueType, gender, pathway);
-        if (!routeResult?.success) {
-          throw new Error(routeResult?.error || 'ROUTE_PERSISTENCE_FAILED');
-        }
-      }
-
-      setStations(prepared);
-      await enterStation(prepared[0], 0);
+      await refreshJourney({ enterIfMissing: true });
     } catch (err) {
       console.error('[PatientPageThemeAware] loadPathway:', err);
       setPathwayError(language === 'ar' ? 'تعذر تحميل المسار الطبي. حاول مرة أخرى.' : 'Unable to load the medical pathway. Please try again.');
     } finally {
       setInitialLoading(false);
     }
-  }, [enterStation, gender, language, patientData, patientId, queueType]);
+  }, [language, patientId, refreshJourney]);
 
   const activeIndex = useMemo(() => stations.findIndex((s) => normalize(s.status) === 'ready' && s.yourNumber !== null), [stations]);
   const activeStation = activeIndex >= 0 ? stations[activeIndex] : null;
+  const activeQueueId = activeStation?.queueId || stations.find((station) => station.queueId)?.queueId || patientData?.queueId || null;
   const completedCount = useMemo(() => stations.filter((s) => normalize(s.status) === 'completed').length, [stations]);
   const allCompleted = stations.length > 0 && stations.every((s) => normalize(s.status) === 'completed');
   const progress = stations.length > 0 ? Math.round((completedCount / stations.length) * 100) : 0;
@@ -185,38 +239,42 @@ export function PatientPageThemeAware({ patientData, onLogout, language, toggleL
   useEffect(() => { void loadPathway(); }, [loadPathway]);
 
   useEffect(() => {
-    if (!patientId || !activeStation) return undefined;
-    if (channelRef.current) { supabase.removeChannel(channelRef.current); channelRef.current = null; }
-    const channel = supabase.channel(`patient_queue_${patientId}_${activeStation.id}`).on('postgres_changes', { event: '*', schema: 'public', table: 'unified_queue', filter: `clinic_id=eq.${activeStation.id}` }, async () => {
-      const pos = await queuePosition(activeStation.id, patientId);
-      if (!pos) return;
-      const status = normalize(pos.status);
-      setStations((prev) => {
-        const idx = prev.findIndex((s) => s.id === activeStation.id);
-        if (idx === -1) return prev;
-        if (status === 'completed') return markCompletedAndUnlockNext(prev, idx).map((station, i) => (i === idx ? { ...station, current: pos.current_number, ahead: pos.ahead, totalWaiting: pos.total_waiting } : station));
-        return prev.map((station, i) => (i === idx ? { ...station, yourNumber: pos.display_number, current: pos.current_number, ahead: pos.ahead, totalWaiting: pos.total_waiting, isEntered: true } : station));
-      });
-    }).subscribe();
+    if (!patientId || !activeQueueId) return undefined;
+    if (channelRef.current) {
+      supabase.removeChannel(channelRef.current);
+      channelRef.current = null;
+    }
+
+    const channel = supabase
+      .channel(`queue:${activeQueueId}`)
+      .on('broadcast', { event: 'queue_changed' }, () => {
+        void refreshJourney({ enterIfMissing: false });
+      })
+      .subscribe((status) => setRealtimeStatus(status));
+
     channelRef.current = channel;
-    return () => { if (channelRef.current) { supabase.removeChannel(channelRef.current); channelRef.current = null; } };
-  }, [activeStation, markCompletedAndUnlockNext, patientId]);
+    return () => {
+      if (channelRef.current) {
+        supabase.removeChannel(channelRef.current);
+        channelRef.current = null;
+      }
+      setRealtimeStatus('CLOSED');
+    };
+  }, [activeQueueId, patientId, refreshJourney]);
 
   useEffect(() => {
-    if (!patientId || !activeStation) return undefined;
-    pollTimerRef.current = window.setInterval(async () => {
-      const pos = await queuePosition(activeStation.id, patientId);
-      if (!pos) return;
-      const status = normalize(pos.status);
-      setStations((prev) => {
-        const idx = prev.findIndex((s) => s.id === activeStation.id);
-        if (idx === -1) return prev;
-        if (status === 'completed') return markCompletedAndUnlockNext(prev, idx);
-        return prev.map((station, i) => (i === idx ? { ...station, yourNumber: pos.display_number, current: pos.current_number, ahead: pos.ahead, totalWaiting: pos.total_waiting, isEntered: true } : station));
-      });
-    }, GENERAL_REFRESH_INTERVAL || 10000);
-    return () => { if (pollTimerRef.current) window.clearInterval(pollTimerRef.current); };
-  }, [activeStation, markCompletedAndUnlockNext, patientId]);
+    if (!patientId) return undefined;
+    let inFlight = false;
+    pollTimerRef.current = window.setInterval(() => {
+      if (inFlight || document.visibilityState === 'hidden') return;
+      inFlight = true;
+      void refreshJourney({ enterIfMissing: false })
+        .finally(() => { inFlight = false; });
+    }, Math.max(GENERAL_REFRESH_INTERVAL || 5000, 5000));
+    return () => {
+      if (pollTimerRef.current) window.clearInterval(pollTimerRef.current);
+    };
+  }, [patientId, refreshJourney]);
 
   useEffect(() => {
     if (!patientId) return undefined;
@@ -245,7 +303,7 @@ export function PatientPageThemeAware({ patientData, onLogout, language, toggleL
 
   if (allCompleted) {
     return (
-      <div className="min-h-screen p-4 flex items-center justify-center" style={shellStyle} data-test="completion-screen">
+      <div className="min-h-screen p-4 flex items-center justify-center" style={shellStyle} data-test="completion-screen" data-route-version={routeVersion} data-last-sync-at={lastSyncAt || ''}>
         <div className="max-w-2xl mx-auto text-center space-y-6">
           <img src="/mms-logo.png" alt="اللجنة الطبية العسكرية" className="mx-auto w-24 h-24 object-contain" />
           <CheckCircle className="w-24 h-24 mx-auto" style={accentStyle} />
@@ -298,7 +356,7 @@ export function PatientPageThemeAware({ patientData, onLogout, language, toggleL
   }
 
   return (
-    <div className="min-h-screen bg-transparent px-3 py-4 overflow-x-hidden overflow-y-auto" data-test="patient-page">
+    <div className="min-h-screen bg-transparent px-3 py-4 overflow-x-hidden overflow-y-auto" data-test="patient-page" data-current-clinic={activeStation?.id || ''} data-route-version={routeVersion} data-last-sync-at={lastSyncAt || ''} data-realtime-status={realtimeStatus}>
       {currentNotice && (
         <div className="fixed top-4 right-4 z-50 max-w-sm rounded-2xl border p-4 shadow-2xl backdrop-blur" style={sheetStyle}>
           <div className="flex items-start gap-3">
@@ -360,7 +418,7 @@ export function PatientPageThemeAware({ patientData, onLogout, language, toggleL
               const canEnter = status === 'ready' && !station.isEntered;
               const active = activeIndex === index;
               return (
-                <Card key={station.id} className="border transition-all duration-200" style={status === 'ready' ? { backgroundColor: 'hsl(var(--theme-surface) / 0.8)', borderColor: 'hsl(var(--theme-secondary) / 0.45)' } : status === 'completed' ? { backgroundColor: 'hsl(var(--theme-surface) / 0.65)', borderColor: 'hsl(var(--theme-secondary) / 0.22)', opacity: 0.78 } : { backgroundColor: 'hsl(var(--theme-surface) / 0.56)', borderColor: 'hsl(var(--border) / 0.5)' }}>
+                <Card key={station.id} data-test="route-station" data-clinic-id={station.id} data-status={status} data-order={index + 1} className="border transition-all duration-200" style={status === 'ready' ? { backgroundColor: 'hsl(var(--theme-surface) / 0.8)', borderColor: 'hsl(var(--theme-secondary) / 0.45)' } : status === 'completed' ? { backgroundColor: 'hsl(var(--theme-surface) / 0.65)', borderColor: 'hsl(var(--theme-secondary) / 0.22)', opacity: 0.78 } : { backgroundColor: 'hsl(var(--theme-surface) / 0.56)', borderColor: 'hsl(var(--border) / 0.5)' }}>
                   <CardContent className="p-3.5 sm:p-5">
                     <div className="flex items-center justify-between mb-3 gap-2">
                       <div className="flex items-center gap-2.5 min-w-0 flex-1">

--- a/frontend/src/lib/dynamic-pathways.js
+++ b/frontend/src/lib/dynamic-pathways.js
@@ -19,21 +19,6 @@ function floorLabel(value) {
   return `الطابق ${floor}`;
 }
 
-async function clinicByCode(code) {
-  if (!supabase || !code) return null;
-  for (const field of ['id', 'code']) {
-    const { data, error } = await supabase
-      .from('clinics')
-      .select('id, name, name_ar, name_en, floor, code, is_active')
-      .eq(field, code)
-      .eq('is_active', true)
-      .maybeSingle();
-    if (error) throw error;
-    if (data) return data;
-  }
-  return null;
-}
-
 async function routeCodesFromDb(examType) {
   if (!supabase) return [];
   const keys = [String(examType || '').trim(), examTypeMap[String(examType || '').trim()]].filter(Boolean);
@@ -53,54 +38,40 @@ async function routeCodesFromDb(examType) {
   return [];
 }
 
-async function queueLoad(clinicId) {
-  if (!supabase || !clinicId) return 0;
-  const today = new Date(Date.now() + 3 * 60 * 60 * 1000).toISOString().slice(0, 10);
-  const { count, error } = await supabase
-    .from('unified_queue')
-    .select('*', { count: 'exact', head: true })
-    .eq('clinic_id', clinicId)
-    .eq('queue_date', today)
-    .in('status', ['waiting', 'called', 'in_progress', 'serving']);
+async function loadActiveClinics() {
+  if (!supabase) return [];
+  const { data, error } = await supabase
+    .from('clinics')
+    .select('id, name, name_ar, name_en, floor, code, is_active')
+    .eq('is_active', true);
   if (error) throw error;
-  return Number(count || 0);
-}
-
-function floorRank(floorCode) {
-  const floor = String(floorCode || '').trim();
-  if (floor === 'M' || floor.includes('الميزانين')) return 1;
-  if (floor === 'G' || floor.includes('الأرضي')) return 2;
-  if (floor === '1' || floor.includes('الأول')) return 3;
-  if (floor === '2' || floor.includes('الثاني')) return 4;
-  if (floor === '3' || floor.includes('الثالث')) return 5;
-  return 99;
+  return Array.isArray(data) ? data : [];
 }
 
 async function buildStations(codes) {
-  const clinics = [];
-  for (const code of codes) {
-    const clinic = await clinicByCode(code);
-    if (!clinic) continue;
-    clinics.push({
+  const clinics = await loadActiveClinics();
+  const byIdentifier = new Map();
+  clinics.forEach((clinic) => {
+    if (clinic?.id) byIdentifier.set(String(clinic.id), clinic);
+    if (clinic?.code) byIdentifier.set(String(clinic.code), clinic);
+  });
+
+  const missing = codes.filter((code) => !byIdentifier.has(String(code)));
+  if (missing.length) throw new Error(`ROUTE_CLINICS_UNRESOLVED:${missing.join(',')}`);
+
+  return codes.map((code, index) => {
+    const clinic = byIdentifier.get(String(code));
+    return {
       id: clinic.id,
       code: clinic.code || code,
       name: clinic.name_en || clinic.name,
       nameAr: clinic.name_ar || clinic.name,
       floorCode: clinic.floor,
       floor: floorLabel(clinic.floor),
-    });
-  }
-  const withLoad = await Promise.all(clinics.map(async (clinic) => ({ ...clinic, load: await queueLoad(clinic.id) })));
-  return withLoad.sort((a, b) => (a.load - b.load) || (floorRank(a.floorCode) - floorRank(b.floorCode))).map((clinic, index) => ({
-    id: clinic.id,
-    code: clinic.code,
-    name: clinic.name,
-    nameAr: clinic.nameAr,
-    floor: clinic.floor,
-    floorCode: clinic.floorCode,
-    order: index + 1,
-    status: index === 0 ? 'ready' : 'locked',
-  }));
+      order: index + 1,
+      status: index === 0 ? 'ready' : 'locked',
+    };
+  });
 }
 
 export async function getDynamicMedicalPathway(examType, gender = 'male') {
@@ -112,19 +83,25 @@ export async function getDynamicMedicalPathway(examType, gender = 'male') {
 
 export async function enrichStationsWithClinicData(stations) {
   if (!Array.isArray(stations) || !supabase) return stations;
-  const out = [];
-  for (const station of stations) {
-    const clinic = await clinicByCode(station.code || station.id);
-    out.push(clinic ? {
+  const clinics = await loadActiveClinics();
+  const byIdentifier = new Map();
+  clinics.forEach((clinic) => {
+    if (clinic?.id) byIdentifier.set(String(clinic.id), clinic);
+    if (clinic?.code) byIdentifier.set(String(clinic.code), clinic);
+  });
+
+  return stations.map((station) => {
+    const clinic = byIdentifier.get(String(station.code || station.id));
+    if (!clinic) return station;
+    return {
       ...station,
       id: clinic.id,
       name: clinic.name_en || clinic.name,
       nameAr: clinic.name_ar || clinic.name,
       floorCode: clinic.floor,
       floor: floorLabel(clinic.floor),
-    } : station);
-  }
-  return out;
+    };
+  });
 }
 
 export default getDynamicMedicalPathway;

--- a/tests/production/recruitment-realtime-acceptance.spec.js
+++ b/tests/production/recruitment-realtime-acceptance.spec.js
@@ -1,0 +1,220 @@
+import fs from 'node:fs';
+import { test, expect } from '@playwright/test';
+
+const ACCEPTANCE_FILE = process.env.E2E_ACCEPTANCE_FILE || '/tmp/mmc-acceptance.json';
+const MAX_SYNC_MS = 2500;
+const RECRUITMENT_CLINICS = ['LAB', 'XR', 'BIO', 'EYE', 'INT', 'SUR', 'ENT', 'PSY', 'DNT', 'DER'];
+
+function acceptanceData() {
+  const payload = JSON.parse(fs.readFileSync(ACCEPTANCE_FILE, 'utf8'));
+  const acceptance = payload?.data || payload;
+  if (!acceptance?.patientIds?.[3] || !Array.isArray(acceptance?.doctors)) {
+    throw new Error('RECRUITMENT_ACCEPTANCE_DATA_INVALID');
+  }
+  return acceptance;
+}
+
+function doctorFor(acceptance, clinicId) {
+  const doctor = acceptance.doctors.find((item) => String(item.clinic_id) === String(clinicId));
+  if (!doctor?.username || !doctor?.password) throw new Error(`DOCTOR_MISSING_FOR_${clinicId}`);
+  return doctor;
+}
+
+async function loginPatient(page, patientId) {
+  await page.goto('/');
+  await expect(page.getByRole('heading', { name: /اللجنة الطبية العسكرية|Military Medical Committee/i })).toBeVisible();
+  await page.locator('input[type="text"]').first().fill(patientId);
+  await page.locator('select').selectOption('recruitment');
+  await page.getByRole('button', { name: /تأكيد|Confirm/i }).click();
+  await expect(page.locator('[data-test="patient-page"]')).toBeVisible({ timeout: 30_000 });
+}
+
+async function loginDoctor(page, doctor) {
+  await page.goto('/doctor');
+  await page.getByRole('button', { name: /الطبيب|Doctor/i }).click();
+  await page.locator('input[type="text"]').last().fill(doctor.username);
+  await page.locator('input[type="password"]').last().fill(doctor.password);
+  await page.getByRole('button', { name: /دخول الطبيب|Doctor Login/i }).click();
+  await expect(page.getByText(/لوحة الطبيب|Doctor dashboard/i)).toBeVisible({ timeout: 20_000 });
+}
+
+async function numericAttribute(page, selector, attribute) {
+  const value = await page.locator(selector).getAttribute(attribute);
+  const parsed = Number(value || 0);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+async function waitForVersion(page, previousVersion, startedAt, label) {
+  await expect.poll(
+    () => numericAttribute(page, '[data-test="patient-page"], [data-test="completion-screen"]', 'data-route-version'),
+    { timeout: MAX_SYNC_MS, intervals: [100, 150, 250, 350] },
+  ).toBeGreaterThan(previousVersion);
+  const elapsed = Date.now() - startedAt;
+  expect(elapsed, `${label} exceeded ${MAX_SYNC_MS}ms`).toBeLessThanOrEqual(MAX_SYNC_MS);
+  return elapsed;
+}
+
+async function stationSnapshot(page) {
+  return page.locator('[data-test="route-station"]').evaluateAll((nodes) => nodes.map((node) => ({
+    clinicId: node.getAttribute('data-clinic-id'),
+    status: node.getAttribute('data-status'),
+    order: Number(node.getAttribute('data-order')),
+  })));
+}
+
+async function assertStationLocking(page, expectedCurrentClinic = null) {
+  const snapshot = await stationSnapshot(page);
+  expect(snapshot.length).toBeGreaterThan(0);
+  const ready = snapshot.filter((station) => station.status === 'ready');
+  expect(ready).toHaveLength(1);
+  if (expectedCurrentClinic) expect(ready[0].clinicId).toBe(expectedCurrentClinic);
+
+  const readyIndex = snapshot.findIndex((station) => station.status === 'ready');
+  snapshot.forEach((station, index) => {
+    if (index < readyIndex) expect(station.status).toBe('completed');
+    if (index > readyIndex) expect(station.status).toBe('locked');
+  });
+  return snapshot;
+}
+
+async function clonePatientToSecondPhone(browser, sourcePage) {
+  const state = await sourcePage.evaluate(() => ({
+    patientData: localStorage.getItem('patientData'),
+    selectedTheme: localStorage.getItem('selectedTheme'),
+    language: localStorage.getItem('mmc_language') || localStorage.getItem('language'),
+  }));
+  expect(state.patientData).toBeTruthy();
+
+  const context = await browser.newContext({
+    viewport: { width: 390, height: 844 },
+    deviceScaleFactor: 3,
+    isMobile: true,
+    hasTouch: true,
+    locale: 'ar-QA',
+    timezoneId: 'Asia/Qatar',
+  });
+  await context.addInitScript((stored) => {
+    if (stored.patientData) localStorage.setItem('patientData', stored.patientData);
+    if (stored.selectedTheme) localStorage.setItem('selectedTheme', stored.selectedTheme);
+    if (stored.language) localStorage.setItem('mmc_language', stored.language);
+  }, state);
+  const page = await context.newPage();
+  await page.goto('/');
+  await expect(page.locator('[data-test="patient-page"]')).toBeVisible({ timeout: 30_000 });
+  return { context, page };
+}
+
+async function waitForRealtimeSubscription(page) {
+  await expect.poll(
+    () => page.locator('[data-test="patient-page"]').getAttribute('data-realtime-status'),
+    { timeout: 15_000 },
+  ).toBe('SUBSCRIBED');
+}
+
+async function runDoctorTransition({ doctorPage, patientPages, doctor, clinicId, isLast, timings }) {
+  await loginDoctor(doctorPage, doctor);
+  await expect(doctorPage.getByText(clinicId, { exact: false })).toBeVisible();
+
+  const runAndObserve = async (buttonName, label) => {
+    const previous = await Promise.all(patientPages.map((page) => numericAttribute(
+      page,
+      '[data-test="patient-page"], [data-test="completion-screen"]',
+      'data-route-version',
+    )));
+    const startedAt = Date.now();
+    await doctorPage.getByRole('button', { name: buttonName }).click();
+    await Promise.all(patientPages.map((page, index) => waitForVersion(page, previous[index], startedAt, label)));
+    timings.push({ clinicId, action: label, elapsedMs: Date.now() - startedAt });
+  };
+
+  await runAndObserve(/استدعاء التالي|Call next/i, 'call');
+  await runAndObserve(/بدء الفحص|Start exam/i, 'start');
+  await runAndObserve(/تمرير الدور|Advance/i, 'advance');
+
+  if (isLast) {
+    await Promise.all(patientPages.map((page) => expect(page.locator('[data-test="completion-screen"]')).toBeVisible({ timeout: 15_000 })));
+  } else {
+    await Promise.all(patientPages.map((page) => expect(page.locator('[data-test="patient-page"]')).toBeVisible()));
+  }
+
+  await doctorPage.getByRole('button', { name: /خروج|Logout/i }).click();
+}
+
+test.describe.configure({ mode: 'serial' });
+
+test('completes recruitment through every clinic with locked routes and synchronized phone screens', async ({ browser }, testInfo) => {
+  test.setTimeout(12 * 60 * 1000);
+  const acceptance = acceptanceData();
+  const patientId = acceptance.patientIds[3];
+  const timings = [];
+
+  const phoneOneContext = await browser.newContext({
+    viewport: { width: 393, height: 852 },
+    deviceScaleFactor: 3,
+    isMobile: true,
+    hasTouch: true,
+    locale: 'ar-QA',
+    timezoneId: 'Asia/Qatar',
+  });
+  const doctorContext = await browser.newContext({ locale: 'ar-QA', timezoneId: 'Asia/Qatar' });
+  const phoneOne = await phoneOneContext.newPage();
+  const doctorPage = await doctorContext.newPage();
+
+  try {
+    await loginPatient(phoneOne, patientId);
+    const initial = await assertStationLocking(phoneOne);
+    expect(initial.map((station) => station.clinicId).sort()).toEqual([...RECRUITMENT_CLINICS].sort());
+    expect(initial).toHaveLength(RECRUITMENT_CLINICS.length);
+
+    const { context: phoneTwoContext, page: phoneTwo } = await clonePatientToSecondPhone(browser, phoneOne);
+    try {
+      await waitForRealtimeSubscription(phoneOne);
+      await waitForRealtimeSubscription(phoneTwo);
+      await assertStationLocking(phoneTwo, initial.find((station) => station.status === 'ready').clinicId);
+
+      for (let index = 0; index < RECRUITMENT_CLINICS.length; index += 1) {
+        const phoneOneSnapshot = await assertStationLocking(phoneOne);
+        const currentClinic = phoneOneSnapshot.find((station) => station.status === 'ready')?.clinicId;
+        expect(currentClinic).toBeTruthy();
+        await assertStationLocking(phoneTwo, currentClinic);
+
+        const doctor = doctorFor(acceptance, currentClinic);
+        await runDoctorTransition({
+          doctorPage,
+          patientPages: [phoneOne, phoneTwo],
+          doctor,
+          clinicId: currentClinic,
+          isLast: index === RECRUITMENT_CLINICS.length - 1,
+          timings,
+        });
+
+        if (index < RECRUITMENT_CLINICS.length - 1) {
+          const afterOne = await assertStationLocking(phoneOne);
+          const nextClinic = afterOne.find((station) => station.status === 'ready')?.clinicId;
+          expect(nextClinic).not.toBe(currentClinic);
+          await assertStationLocking(phoneTwo, nextClinic);
+        }
+      }
+
+      await expect(phoneOne.locator('[data-test="completion-screen"]')).toBeVisible();
+      await expect(phoneTwo.locator('[data-test="completion-screen"]')).toBeVisible();
+      await testInfo.attach('recruitment-realtime-timings.json', {
+        body: Buffer.from(JSON.stringify(timings, null, 2)),
+        contentType: 'application/json',
+      });
+      await testInfo.attach('recruitment-completed-phone-one.png', {
+        body: await phoneOne.screenshot({ fullPage: true }),
+        contentType: 'image/png',
+      });
+      await testInfo.attach('recruitment-completed-phone-two.png', {
+        body: await phoneTwo.screenshot({ fullPage: true }),
+        contentType: 'image/png',
+      });
+    } finally {
+      await phoneTwoContext.close();
+    }
+  } finally {
+    await phoneOneContext.close();
+    await doctorContext.close();
+  }
+});


### PR DESCRIPTION
## Scope
- Use the server-returned canonical route instead of a client-reordered route.
- Restore the correct current clinic after refresh or phone reconnect.
- Broadcast sanitized queue transitions on the opaque queue UUID and retain signed five-second non-overlapping polling as a fallback.
- Add non-visual test attributes for station locking, current clinic, route version, and synchronization timing.
- Complete a fourth recruitment journey across all configured clinics on two independent phone contexts.
- Extend production acceptance to four isolated patients and verify persisted queue/event/statistics records before cleanup.

## Non-goals
- No visual identity changes.
- No changes to displayed wording or medical form layout.
- No real credentials or permanent test data.

## Gates passed before merge
- Frontend CI.
- Secret scanning.
- Duplicate active component guard.
- All review threads resolved.
- Backend weighted routing, Broadcast publisher, OIDC verification, and cleanup isolation deployed and healthy.

## Post-merge production gate
The OIDC Playwright workflow must complete all four journeys, verify database persistence and doctor statistics, and clean all isolated acceptance data.