### PR TITLE
fix: localize patient validation and stabilize clinic acceptance locator

### DIFF
--- a/frontend/src/components/LoginPage.jsx
+++ b/frontend/src/components/LoginPage.jsx
@@ -314,7 +314,7 @@ export function LoginPage({ onLogin, onAdminLogin, onDoctorLogin, currentTheme, 
             )}
 
             {!isAdminMode && !isDoctorMode ? (
-              <form onSubmit={handleSubmit} className="space-y-6">
+              <form noValidate onSubmit={handleSubmit} className="space-y-6">
                 <div>
                   <div className="flex items-center justify-between mb-2">
                     <label className="block text-sm font-medium text-gray-300">

--- a/tests/production/recruitment-realtime-acceptance.spec.js
+++ b/tests/production/recruitment-realtime-acceptance.spec.js
@@ -113,7 +113,7 @@ async function waitForRealtimeSubscription(page) {
 
 async function runDoctorTransition({ doctorPage, patientPages, doctor, clinicId, isLast, timings }) {
   await loginDoctor(doctorPage, doctor);
-  await expect(doctorPage.getByText(clinicId, { exact: false })).toBeVisible();
+  await expect(doctorPage.getByText(clinicId, { exact: true })).toBeVisible();
 
   const runAndObserve = async (buttonName, label) => {
     const previous = await Promise.all(patientPages.map((page) => numericAttribute(


### PR DESCRIPTION
## Scope
- Disable native HTML form validation for the patient form so the existing Arabic/English application validation is always displayed.
- Make the recruitment doctor clinic assertion exact to avoid Playwright strict-mode ambiguity.

## Safety
- No visual identity changes.
- No medical workflow changes.
- No credentials or test data in the repository.

## Gate
A clean two-file commit will be materialized, reviewed, built, merged, and followed by a fresh production acceptance run.