### PR TITLE
fix: gate production on exact commit and authenticate both patient phones

### DIFF
--- a/.github/workflows/production-ui-acceptance.yml
+++ b/.github/workflows/production-ui-acceptance.yml
@@ -39,20 +39,32 @@ jobs:
       - name: Install Chromium
         run: npx playwright install --with-deps chromium
 
-      - name: Verify production is reachable
+      - name: Verify exact production commit is reachable
         shell: bash
         run: |
           set -euo pipefail
-          for attempt in {1..30}; do
-            status=$(curl -sS -o /tmp/mmc-production.html -w '%{http_code}' "$E2E_BASE_URL" || true)
-            if [ "$status" = "200" ] && grep -q 'Military Medical Committee\|اللجنة الطبية العسكرية' /tmp/mmc-production.html; then
-              echo "Production frontend is reachable"
+          expected_sha="$GITHUB_SHA"
+
+          for attempt in {1..60}; do
+            html_status=$(curl -sS -o /tmp/mmc-production.html -w '%{http_code}' \
+              "$E2E_BASE_URL/?release_sha=${expected_sha}&attempt=${attempt}" || true)
+            meta_status=$(curl -sS -o /tmp/mmc-build-meta.json -w '%{http_code}' \
+              "$E2E_BASE_URL/build-meta.json?release_sha=${expected_sha}&attempt=${attempt}" || true)
+            served_sha=$(jq -r '.commitSha // empty' /tmp/mmc-build-meta.json 2>/dev/null || true)
+
+            if [ "$html_status" = "200" ] \
+              && [ "$meta_status" = "200" ] \
+              && grep -q 'Military Medical Committee\|اللجنة الطبية العسكرية' /tmp/mmc-production.html \
+              && [ "$served_sha" = "$expected_sha" ]; then
+              echo "Production frontend is serving exact commit $expected_sha"
               exit 0
             fi
-            echo "Production is not ready: HTTP $status (attempt $attempt)"
+
+            echo "Production commit mismatch: expected=$expected_sha served=${served_sha:-missing} html=$html_status meta=$meta_status attempt=$attempt"
             sleep 10
           done
-          echo "Production frontend did not become ready"
+
+          echo "Production frontend did not deploy exact commit $expected_sha"
           exit 1
 
       - name: Bootstrap isolated acceptance accounts with GitHub OIDC

--- a/frontend/scripts/sync-runtime-config.mjs
+++ b/frontend/scripts/sync-runtime-config.mjs
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -11,9 +12,34 @@ const sources = [
   'clinics.json',
 ];
 
+function resolveCommitSha() {
+  const environmentSha = String(
+    process.env.VERCEL_GIT_COMMIT_SHA
+      || process.env.GITHUB_SHA
+      || process.env.COMMIT_SHA
+      || '',
+  ).trim();
+
+  if (/^[a-f0-9]{40}$/i.test(environmentSha)) return environmentSha.toLowerCase();
+
+  try {
+    const gitSha = execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: path.resolve(frontendRoot, '..'),
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    if (/^[a-f0-9]{40}$/i.test(gitSha)) return gitSha.toLowerCase();
+  } catch {
+    // CLI deployments may omit the Git repository. The release gate rejects unknown SHAs.
+  }
+
+  return 'unknown';
+}
+
 async function sync() {
   const srcDir = path.join(frontendRoot, 'config');
-  const destDir = path.join(frontendRoot, 'public', 'config');
+  const publicDir = path.join(frontendRoot, 'public');
+  const destDir = path.join(publicDir, 'config');
   await mkdir(destDir, { recursive: true });
 
   for (const filename of sources) {
@@ -24,6 +50,20 @@ async function sync() {
     await writeFile(dest, normalized, 'utf8');
     console.log(`synced ${filename}`);
   }
+
+  const buildMeta = {
+    commitSha: resolveCommitSha(),
+    environment: process.env.VERCEL_ENV || process.env.NODE_ENV || 'local',
+    deploymentId: process.env.VERCEL_DEPLOYMENT_ID || null,
+    builtAt: new Date().toISOString(),
+  };
+
+  await writeFile(
+    path.join(publicDir, 'build-meta.json'),
+    `${JSON.stringify(buildMeta, null, 2)}\n`,
+    'utf8',
+  );
+  console.log(`synced build-meta.json (${buildMeta.commitSha})`);
 }
 
 sync().catch((err) => {

--- a/tests/production/recruitment-realtime-acceptance.spec.js
+++ b/tests/production/recruitment-realtime-acceptance.spec.js
@@ -77,14 +77,7 @@ async function assertStationLocking(page, expectedCurrentClinic = null) {
   return snapshot;
 }
 
-async function clonePatientToSecondPhone(browser, sourcePage) {
-  const state = await sourcePage.evaluate(() => ({
-    patientData: localStorage.getItem('patientData'),
-    selectedTheme: localStorage.getItem('selectedTheme'),
-    language: localStorage.getItem('mmc_language') || localStorage.getItem('language'),
-  }));
-  expect(state.patientData).toBeTruthy();
-
+async function loginPatientOnSecondPhone(browser, patientId) {
   const context = await browser.newContext({
     viewport: { width: 390, height: 844 },
     deviceScaleFactor: 3,
@@ -93,14 +86,8 @@ async function clonePatientToSecondPhone(browser, sourcePage) {
     locale: 'ar-QA',
     timezoneId: 'Asia/Qatar',
   });
-  await context.addInitScript((stored) => {
-    if (stored.patientData) localStorage.setItem('patientData', stored.patientData);
-    if (stored.selectedTheme) localStorage.setItem('selectedTheme', stored.selectedTheme);
-    if (stored.language) localStorage.setItem('mmc_language', stored.language);
-  }, state);
   const page = await context.newPage();
-  await page.goto('/');
-  await expect(page.locator('[data-test="patient-page"]')).toBeVisible({ timeout: 30_000 });
+  await loginPatient(page, patientId);
   return { context, page };
 }
 
@@ -166,7 +153,7 @@ test('completes recruitment through every clinic with locked routes and synchron
     expect(initial.map((station) => station.clinicId).sort()).toEqual([...RECRUITMENT_CLINICS].sort());
     expect(initial).toHaveLength(RECRUITMENT_CLINICS.length);
 
-    const { context: phoneTwoContext, page: phoneTwo } = await clonePatientToSecondPhone(browser, phoneOne);
+    const { context: phoneTwoContext, page: phoneTwo } = await loginPatientOnSecondPhone(browser, patientId);
     try {
       await waitForRealtimeSubscription(phoneOne);
       await waitForRealtimeSubscription(phoneTwo);


### PR DESCRIPTION
## Scope
- Emit `build-meta.json` from the exact Git/Vercel commit used for the frontend build.
- Refuse to start production acceptance until `mmc-mms.com` serves the same commit as the workflow run.
- Authenticate the second mobile browser independently with the same patient identity instead of copying local storage without a signed session.

## Why
The previous production run tested a stale custom-domain deployment, and the second phone could subscribe to the public sanitized Broadcast channel but could not refresh the protected patient route without its own signed session.

## Safety
- No visual identity changes.
- No medical routing or queue state-machine changes.
- No credentials or permanent test data.
- OIDC-isolated test data remains subject to unconditional cleanup.

## Acceptance
- Frontend CI, Secret Scanning, and duplicate component guard pass.
- The post-merge gate proves the exact deployed SHA.
- Four production journeys complete, including recruitment across every configured clinic on two independently authenticated phone contexts.
- Database events, doctor statistics, examination records, and cleanup all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added build metadata to deployed frontend assets, including commit, environment, deployment ID, and build time.
* **Bug Fixes**
  * Production checks now confirm that the deployed frontend matches the expected commit and provide clearer failure details.
  * Improved real-time acceptance testing by authenticating separate browser sessions through the standard login flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->