### PR TITLE
fix: prove realtime delivery and persist patient session before RLS writes

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -258,6 +258,22 @@ function App() {
       const patientPayload = response.data || response.patient || response.session || response;
       if (!patientPayload?.token) throw new Error('PATIENT_SESSION_MISSING');
 
+      const finalPatientData = {
+        ...patientPayload,
+        queueType: examType,
+        examType,
+        gender,
+      };
+
+      localStorage.removeItem('mmc_admin_session');
+      localStorage.removeItem('mmc_doctor_session');
+      localStorage.removeItem('mmc_clinic_session');
+      localStorage.setItem('patientData', JSON.stringify(finalPatientData));
+      setIsAdmin(false);
+      setDoctorSession(null);
+      setPatientData(finalPatientData);
+
+      // Persist the signed patient session before writes protected by patient-scoped RLS.
       try {
         await registerDeviceLogin(patientId);
       } catch (registrationError) {
@@ -276,21 +292,6 @@ function App() {
         console.warn('[App] logDailyActivity failed:', logError);
       }
 
-      localStorage.removeItem('mmc_admin_session');
-      localStorage.removeItem('mmc_doctor_session');
-      localStorage.removeItem('mmc_clinic_session');
-      setIsAdmin(false);
-      setDoctorSession(null);
-
-      const finalPatientData = {
-        ...patientPayload,
-        queueType: examType,
-        examType,
-        gender,
-      };
-
-      setPatientData(finalPatientData);
-      localStorage.setItem('patientData', JSON.stringify(finalPatientData));
       setCurrentView('patient');
       showNotification(language === 'ar' ? 'تم تسجيل الدخول بنجاح' : 'Login successful', 'success');
     } catch (error) {

--- a/frontend/src/components/PatientPageThemeAware.jsx
+++ b/frontend/src/components/PatientPageThemeAware.jsx
@@ -81,6 +81,7 @@ export function PatientPageThemeAware({ patientData, onLogout, language, toggleL
   const [routeVersion, setRouteVersion] = useState(0);
   const [lastSyncAt, setLastSyncAt] = useState(null);
   const [realtimeStatus, setRealtimeStatus] = useState('IDLE');
+  const [realtimeEventCount, setRealtimeEventCount] = useState(0);
   const channelRef = useRef(null);
   const pollTimerRef = useRef(null);
   const noticeTimerRef = useRef(null);
@@ -246,8 +247,9 @@ export function PatientPageThemeAware({ patientData, onLogout, language, toggleL
     }
 
     const channel = supabase
-      .channel(`queue:${activeQueueId}`)
+      .channel(`queue:${activeQueueId}`, { config: { private: false } })
       .on('broadcast', { event: 'queue_changed' }, () => {
+        setRealtimeEventCount((count) => count + 1);
         void refreshJourney({ enterIfMissing: false });
       })
       .subscribe((status) => setRealtimeStatus(status));
@@ -303,7 +305,7 @@ export function PatientPageThemeAware({ patientData, onLogout, language, toggleL
 
   if (allCompleted) {
     return (
-      <div className="min-h-screen p-4 flex items-center justify-center" style={shellStyle} data-test="completion-screen" data-route-version={routeVersion} data-last-sync-at={lastSyncAt || ''}>
+      <div className="min-h-screen p-4 flex items-center justify-center" style={shellStyle} data-test="completion-screen" data-route-version={routeVersion} data-last-sync-at={lastSyncAt || ''} data-realtime-status={realtimeStatus} data-realtime-events={realtimeEventCount}>
         <div className="max-w-2xl mx-auto text-center space-y-6">
           <img src="/mms-logo.png" alt="اللجنة الطبية العسكرية" className="mx-auto w-24 h-24 object-contain" />
           <CheckCircle className="w-24 h-24 mx-auto" style={accentStyle} />
@@ -356,7 +358,7 @@ export function PatientPageThemeAware({ patientData, onLogout, language, toggleL
   }
 
   return (
-    <div className="min-h-screen bg-transparent px-3 py-4 overflow-x-hidden overflow-y-auto" data-test="patient-page" data-current-clinic={activeStation?.id || ''} data-route-version={routeVersion} data-last-sync-at={lastSyncAt || ''} data-realtime-status={realtimeStatus}>
+    <div className="min-h-screen bg-transparent px-3 py-4 overflow-x-hidden overflow-y-auto" data-test="patient-page" data-current-clinic={activeStation?.id || ''} data-route-version={routeVersion} data-last-sync-at={lastSyncAt || ''} data-realtime-status={realtimeStatus} data-realtime-events={realtimeEventCount}>
       {currentNotice && (
         <div className="fixed top-4 right-4 z-50 max-w-sm rounded-2xl border p-4 shadow-2xl backdrop-blur" style={sheetStyle}>
           <div className="flex items-start gap-3">

--- a/tests/production/full-application-acceptance.spec.js
+++ b/tests/production/full-application-acceptance.spec.js
@@ -293,7 +293,7 @@ test.describe.serial('production application acceptance', () => {
     await patientForm.locator('input[type="text"]').first().fill('1');
     await patientForm.locator('select').first().selectOption('promotion');
     await patientForm.getByRole('button', { name: /تأكيد|Confirm/i }).click();
-    await expect(page.getByText(/2 إلى 12|2-12|غير صالح|invalid/i).first()).toBeVisible();
+    await expect(page.getByText(/قصير|الحد الأدنى\s*2|2 إلى 12|2-12|غير صالح|invalid/i).first()).toBeVisible();
 
     await page.getByRole('button', { name: /أنثى|Female/i }).click();
     await expect(page.getByText(/ملاحظة مهمة للعنصر النسائي|important.*female/i)).toBeVisible();

--- a/tests/production/recruitment-realtime-acceptance.spec.js
+++ b/tests/production/recruitment-realtime-acceptance.spec.js
@@ -54,6 +54,16 @@ async function waitForVersion(page, previousVersion, startedAt, label) {
   return elapsed;
 }
 
+async function waitForRealtimeEvent(page, previousCount, startedAt, label) {
+  await expect.poll(
+    () => numericAttribute(page, '[data-test="patient-page"], [data-test="completion-screen"]', 'data-realtime-events'),
+    { timeout: MAX_SYNC_MS, intervals: [50, 100, 150, 250] },
+  ).toBeGreaterThan(previousCount);
+  const elapsed = Date.now() - startedAt;
+  expect(elapsed, `${label} broadcast exceeded ${MAX_SYNC_MS}ms`).toBeLessThanOrEqual(MAX_SYNC_MS);
+  return elapsed;
+}
+
 async function stationSnapshot(page) {
   return page.locator('[data-test="route-station"]').evaluateAll((nodes) => nodes.map((node) => ({
     clinicId: node.getAttribute('data-clinic-id'),
@@ -103,14 +113,20 @@ async function runDoctorTransition({ doctorPage, patientPages, doctor, clinicId,
   await expect(doctorPage.getByText(clinicId, { exact: true })).toBeVisible();
 
   const runAndObserve = async (buttonName, label) => {
-    const previous = await Promise.all(patientPages.map((page) => numericAttribute(
+    const previousVersions = await Promise.all(patientPages.map((page) => numericAttribute(
       page,
       '[data-test="patient-page"], [data-test="completion-screen"]',
       'data-route-version',
     )));
+    const previousEvents = await Promise.all(patientPages.map((page) => numericAttribute(
+      page,
+      '[data-test="patient-page"], [data-test="completion-screen"]',
+      'data-realtime-events',
+    )));
     const startedAt = Date.now();
     await doctorPage.getByRole('button', { name: buttonName }).click();
-    await Promise.all(patientPages.map((page, index) => waitForVersion(page, previous[index], startedAt, label)));
+    await Promise.all(patientPages.map((page, index) => waitForRealtimeEvent(page, previousEvents[index], startedAt, label)));
+    await Promise.all(patientPages.map((page, index) => waitForVersion(page, previousVersions[index], startedAt, label)));
     timings.push({ clinicId, action: label, elapsedMs: Date.now() - startedAt });
   };
 


### PR DESCRIPTION
## Scope
- Subscribe to the public queue Broadcast channel explicitly and count received events in non-visual test attributes.
- Require both mobile contexts to receive each Broadcast before accepting the corresponding queue version update.
- Persist the signed patient session before patient-scoped `device_logins` and `daily_activity_logs` writes.
- Align the validation assertion with the real localized short-number message.

## Safety
- No visual identity changes.
- No queue state-machine or route ordering changes.
- No credentials or permanent test data.
- Final materialized commit is based on the exact current `main` and contains only four application/test files.

## Gate
The temporary materializer builds the transformed application and emits an unattached clean commit. The branch will then be moved to that clean commit before review and merge.