### PR TITLE
fix: restore floor directions and measure true realtime callback latency

### DIFF
--- a/frontend/src/components/AdminDashboardV2.jsx
+++ b/frontend/src/components/AdminDashboardV2.jsx
@@ -6015,6 +6015,7 @@ export const AdminDashboardV2 = ({ onLogout, language, toggleLanguage }) => {
     { id: 'doctor_control', icon: Stethoscope, label: t('شاشة الطبيب', 'Doctor Control') },
     { id: 'notifications', icon: Bell, label: t('الإشعارات', 'Notifications') },
     { id: 'routes', icon: MapPin, label: t('المسارات', 'Routes') },
+    { id: 'floor_directions', icon: MapPin, label: t('توجيه الطوابق', 'Floor Directions') },
     { id: 'reports', icon: FileText, label: t('التقارير', 'Reports') },
     { id: 'clinics', icon: Activity, label: t('العيادات', 'Clinics') },
     { id: 'system', icon: Shield, label: t('حالة النظام', 'System Status') },

--- a/frontend/src/components/NotificationsManagementV2.jsx
+++ b/frontend/src/components/NotificationsManagementV2.jsx
@@ -89,7 +89,7 @@ const NotificationsManagementV2 = ({ language, t }) => {
       const today = new Date().toISOString().split('T')[0];
       const { data } = await supabase
         .from('patients')
-        .select('id, military_number, gender')
+        .select('id, patient_id, gender')
         .gte('created_at', `${today}T00:00:00`)
         .order('created_at', { ascending: false });
       if (data) setPatients(data);

--- a/frontend/src/components/PatientPageThemeAware.jsx
+++ b/frontend/src/components/PatientPageThemeAware.jsx
@@ -82,6 +82,7 @@ export function PatientPageThemeAware({ patientData, onLogout, language, toggleL
   const [lastSyncAt, setLastSyncAt] = useState(null);
   const [realtimeStatus, setRealtimeStatus] = useState('IDLE');
   const [realtimeEventCount, setRealtimeEventCount] = useState(0);
+  const [realtimeLastEventAt, setRealtimeLastEventAt] = useState(0);
   const channelRef = useRef(null);
   const pollTimerRef = useRef(null);
   const noticeTimerRef = useRef(null);
@@ -249,6 +250,7 @@ export function PatientPageThemeAware({ patientData, onLogout, language, toggleL
     const channel = supabase
       .channel(`queue:${activeQueueId}`, { config: { private: false } })
       .on('broadcast', { event: 'queue_changed' }, () => {
+        setRealtimeLastEventAt(Date.now());
         setRealtimeEventCount((count) => count + 1);
         void refreshJourney({ enterIfMissing: false });
       })
@@ -305,7 +307,7 @@ export function PatientPageThemeAware({ patientData, onLogout, language, toggleL
 
   if (allCompleted) {
     return (
-      <div className="min-h-screen p-4 flex items-center justify-center" style={shellStyle} data-test="completion-screen" data-route-version={routeVersion} data-last-sync-at={lastSyncAt || ''} data-realtime-status={realtimeStatus} data-realtime-events={realtimeEventCount}>
+      <div className="min-h-screen p-4 flex items-center justify-center" style={shellStyle} data-test="completion-screen" data-route-version={routeVersion} data-last-sync-at={lastSyncAt || ''} data-realtime-status={realtimeStatus} data-realtime-events={realtimeEventCount} data-realtime-last-event-at={realtimeLastEventAt}>
         <div className="max-w-2xl mx-auto text-center space-y-6">
           <img src="/mms-logo.png" alt="اللجنة الطبية العسكرية" className="mx-auto w-24 h-24 object-contain" />
           <CheckCircle className="w-24 h-24 mx-auto" style={accentStyle} />
@@ -358,7 +360,7 @@ export function PatientPageThemeAware({ patientData, onLogout, language, toggleL
   }
 
   return (
-    <div className="min-h-screen bg-transparent px-3 py-4 overflow-x-hidden overflow-y-auto" data-test="patient-page" data-current-clinic={activeStation?.id || ''} data-route-version={routeVersion} data-last-sync-at={lastSyncAt || ''} data-realtime-status={realtimeStatus} data-realtime-events={realtimeEventCount}>
+    <div className="min-h-screen bg-transparent px-3 py-4 overflow-x-hidden overflow-y-auto" data-test="patient-page" data-current-clinic={activeStation?.id || ''} data-route-version={routeVersion} data-last-sync-at={lastSyncAt || ''} data-realtime-status={realtimeStatus} data-realtime-events={realtimeEventCount} data-realtime-last-event-at={realtimeLastEventAt}>
       {currentNotice && (
         <div className="fixed top-4 right-4 z-50 max-w-sm rounded-2xl border p-4 shadow-2xl backdrop-blur" style={sheetStyle}>
           <div className="flex items-start gap-3">

--- a/tests/production/recruitment-realtime-acceptance.spec.js
+++ b/tests/production/recruitment-realtime-acceptance.spec.js
@@ -59,7 +59,14 @@ async function waitForRealtimeEvent(page, previousCount, startedAt, label) {
     () => numericAttribute(page, '[data-test="patient-page"], [data-test="completion-screen"]', 'data-realtime-events'),
     { timeout: MAX_SYNC_MS, intervals: [50, 100, 150, 250] },
   ).toBeGreaterThan(previousCount);
-  const elapsed = Date.now() - startedAt;
+
+  const receivedAt = await numericAttribute(
+    page,
+    '[data-test="patient-page"], [data-test="completion-screen"]',
+    'data-realtime-last-event-at',
+  );
+  expect(receivedAt, `${label} broadcast timestamp missing`).toBeGreaterThanOrEqual(startedAt);
+  const elapsed = receivedAt - startedAt;
   expect(elapsed, `${label} broadcast exceeded ${MAX_SYNC_MS}ms`).toBeLessThanOrEqual(MAX_SYNC_MS);
   return elapsed;
 }


### PR DESCRIPTION
## Scope
- Restore the existing Floor Directions manager to the admin navigation without changing its component or visual style.
- Use the canonical `patients.patient_id` column in notifications instead of the removed `military_number` column.
- Record the browser callback timestamp when each sanitized queue Broadcast reaches the patient phone.
- Keep the 2500ms acceptance limit and calculate latency from the doctor action start to the callback timestamp, excluding Playwright polling delay.

## Evidence
- Production accessibility snapshot proved the Floor Directions component was unreachable because its menu item was absent.
- PostgreSQL logged `column patients.military_number does not exist` while the current schema exposes `patient_id`.
- Both patient phones received the first queue Broadcast, but the previous measurement included the doctor button/network wait before polling and reported 2911ms.

## Safety
- No medical state-machine, route-weighting, or visual identity changes.
- No credentials or permanent test data.
- The final clean commit will contain only four application/test files and will be rebuilt before merge.