### PR TITLE
test: wait for clinic displays and time only enabled doctor actions

### DIFF
--- a/tests/production/full-application-acceptance.spec.js
+++ b/tests/production/full-application-acceptance.spec.js
@@ -308,6 +308,7 @@ test.describe.serial('production application acceptance', () => {
       const displayEvidence = evidenceCollector(displayPage);
       await displayPage.goto(`/clinic/${encodeURIComponent(clinicId)}/display`, { waitUntil: 'domcontentloaded' });
       await expect(displayPage.locator('body')).not.toContainText(/Application error|AdminPage Error/i);
+      await expect(displayPage.getByRole('heading').first()).toBeVisible({ timeout: 20_000 });
       const displayInventory = await inventory(displayPage, testInfo, `display-${clinicId}`);
       expect(displayInventory.headings.length, `display heading missing for ${clinicId}`).toBeGreaterThan(0);
       await assertEvidence(testInfo, `display-${clinicId}`, displayEvidence);

--- a/tests/production/recruitment-realtime-acceptance.spec.js
+++ b/tests/production/recruitment-realtime-acceptance.spec.js
@@ -137,8 +137,10 @@ async function runDoctorTransition({ doctorPage, patientPages, doctor, clinicId,
       '[data-test="patient-page"], [data-test="completion-screen"]',
       'data-realtime-events',
     )));
+    const actionButton = doctorPage.getByRole('button', { name: buttonName });
+    await expect(actionButton).toBeEnabled();
     const startedAt = Date.now();
-    await doctorPage.getByRole('button', { name: buttonName }).click();
+    await actionButton.click();
     await Promise.all(patientPages.map((page, index) => waitForRealtimeEvent(page, previousEvents[index], startedAt, label)));
     await Promise.all(patientPages.map((page, index) => waitForVersion(page, previousVersions[index], startedAt, label)));
     timings.push({ clinicId, action: label, elapsedMs: Date.now() - startedAt });


### PR DESCRIPTION
## Scope
- Wait for each clinic display heading to become visible after `domcontentloaded` instead of inventorying the loading spinner immediately.
- Wait for the doctor action button to become enabled before starting the existing 2500ms synchronization timer.

## Evidence
- The AUD display was captured 0.44s after navigation while the page showed `جار التحميل...`; its public queue-status API returns HTTP 200 with the expected contract.
- The Playwright trace shows the Start Exam button remained disabled for 924ms inside `locator.click()`. The old timer started before that actionability wait and incorrectly counted UI readiness from the previous transition as Realtime latency.

## Safety
- Test-only changes.
- No application logic, visual identity, queue state machine, or timing threshold changes.
- Final materialized commit will contain exactly two test files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated updates to end-to-end tests to wait for page content and interactive controls to become ready before proceeding.
  * Added validation to ensure expected test updates are applied consistently.
* **Chores**
  * Added a pull request workflow that applies, formats, builds, and validates the test transformations automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->