### PR TITLE
test: use current Doctor Management navigation label

### DIFF
--- a/tests/production/full-application-acceptance.spec.js
+++ b/tests/production/full-application-acceptance.spec.js
@@ -348,7 +348,7 @@ test.describe.serial('production application acceptance', () => {
     await attachJson(testInfo, 'admin-sections', visited);
     expect(visited.length).toBe(ADMIN_SECTIONS.length);
 
-    await page.getByRole('button', { name: 'الأطباء', exact: true }).click();
+    await page.getByRole('button', { name: 'إدارة الأطباء', exact: true }).click();
     await expect(page.getByRole('heading', { name: /إدارة الأطباء|Doctor Management/i })).toBeVisible();
 
     const targetDoctor = acceptance.doctors.find((doctor) => doctor.clinic_id === 'LAB') || acceptance.doctors[0];


### PR DESCRIPTION
## Scope
- Replace the single legacy post-inventory click target `الأطباء` with the current visible label `إدارة الأطباء`.

## Evidence
The full admin navigation loop already found and opened `إدارة الأطباء`; the later CRUD phase failed only because it repeated the old exact label.

## Safety
- Test-only one-line change.
- No application logic, design, authentication, routing, or queue behavior changes.
- Final materialized commit will contain exactly one test file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated administrator acceptance coverage to use the current doctor management navigation label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->