### PR TITLE
fix(ci): serialize production acceptance runs

### DIFF
--- a/.github/workflows/production-ui-acceptance.yml
+++ b/.github/workflows/production-ui-acceptance.yml
@@ -10,7 +10,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: production-ui-acceptance-${{ github.run_id }}
+  group: production-ui-acceptance-main
   cancel-in-progress: false
 
 env:


### PR DESCRIPTION
## Cause
The production acceptance workflow used `github.run_id` in its concurrency group, which is unique per run and therefore did not serialize production acceptance executions.

## Fix
Use one stable `production-ui-acceptance-main` concurrency group with `cancel-in-progress: false` so acceptance runs cannot overlap and cleanup remains deterministic.

## Scope
- CI workflow only.
- No application code, UI, routing, authentication, queue logic, database schema, or visible text changes.

## Verification
After merge, the resulting main push will be used for the final full production acceptance against the already deployed frontend and backend release candidate.