### PR TITLE
feat(ci): add owner-only production acceptance trigger

### DIFF
--- a/.github/workflows/production-ui-acceptance.yml
+++ b/.github/workflows/production-ui-acceptance.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+  issue_comment:
+    types: [created]
 
 permissions:
   contents: read
@@ -20,6 +22,13 @@ env:
 
 jobs:
   full-production-acceptance:
+    if: >-
+      github.event_name != 'issue_comment' ||
+      (
+        github.actor == github.repository_owner &&
+        github.event.issue.number == 618 &&
+        github.event.comment.body == '/run-production-acceptance'
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 60
 


### PR DESCRIPTION
## Purpose
Provide a deterministic manual trigger for the existing Production UI Acceptance workflow when the GitHub connector cannot invoke `workflow_dispatch` directly.

## Security
- Trigger is accepted only on PR #618.
- Triggering actor must equal the repository owner.
- Comment body must exactly equal `/run-production-acceptance`.
- The workflow remains serialized with `production-ui-acceptance-main`.
- GitHub `issue_comment` supplies the latest default-branch commit as `GITHUB_SHA`, so the existing exact-production-commit gate remains enforced.

## Scope
CI orchestration only. No frontend behavior, visual identity, backend logic, database schema, routing, authentication, or queue logic changes.