### PR TITLE
fix: keep patient route state monotonic after realtime broadcasts

### DIFF
--- a/frontend/src/components/PatientPageThemeAware.jsx
+++ b/frontend/src/components/PatientPageThemeAware.jsx
@@ -194,16 +194,25 @@ export function PatientPageThemeAware({ patientData, onLogout, language, toggleL
       || ['completed', 'done'].includes(String(route?.status || '').toLowerCase())
       || currentStep >= prepared.length;
 
-    applyRouteVersion(route?.version);
+    const incomingVersion = Number(route?.version || 0);
+    const routeSnapshotIsStale = () => (
+      routeVersionRef.current > 0
+      && (!Number.isFinite(incomingVersion) || incomingVersion <= 0 || incomingVersion < routeVersionRef.current)
+    );
+
+    if (routeSnapshotIsStale()) return route;
+    applyRouteVersion(incomingVersion);
     setLastSyncAt(Date.now());
 
     if (complete) {
+      if (routeSnapshotIsStale()) return route;
       setStations(prepared.map((station) => ({ ...station, status: 'completed', isEntered: false })));
       return route;
     }
 
     const currentStation = prepared[currentStep];
     const position = await queuePosition(currentStation.id, patientId);
+    if (routeSnapshotIsStale()) return route;
     if (position) {
       prepared[currentStep] = {
         ...currentStation,

--- a/tests/production/full-application-acceptance.spec.js
+++ b/tests/production/full-application-acceptance.spec.js
@@ -349,7 +349,7 @@ test.describe.serial('production application acceptance', () => {
     expect(visited.length).toBe(ADMIN_SECTIONS.length);
 
     await page.getByRole('button', { name: 'إدارة الأطباء', exact: true }).click();
-    await expect(page.getByRole('heading', { name: /إدارة الأطباء|Doctor Management/i })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /إدارة حسابات الأطباء|Doctor Accounts|Doctor Management/i })).toBeVisible();
 
     const targetDoctor = acceptance.doctors.find((doctor) => doctor.clinic_id === 'LAB') || acceptance.doctors[0];
     const search = page.getByPlaceholder(/بحث بالاسم|Search by name/i);


### PR DESCRIPTION
## Root cause proven by production Playwright run 31129054770
Both phone contexts received `queue_changed` and advanced route versions within the 2.5s realtime threshold, but one phone regressed from the broadcast-applied `BIO` state back to `XR`. A refresh request started on an older route version could finish after the newer broadcast and overwrite React station state.

## Fix scope
- Reject stale route snapshots in `refreshJourney` when their version is older than `routeVersionRef`.
- Re-check staleness after the awaited queue-position request before writing station state.
- Correct the admin acceptance heading to the accessibility snapshot’s actual visible heading: `إدارة حسابات الأطباء`.

## Non-goals
- No visual changes.
- No route algorithm changes.
- No polling interval changes.
- No backend queue state-machine changes.

## Gate
This PR first materializes a clean two-file commit directly from the exact current `main`; the temporary materializer files are removed from the final diff before merge. Production acceptance will then be rerun end-to-end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved realtime synchronization safeguards to prevent stale updates from overwriting newer data.
  * Enhanced acceptance-test matching for doctor-management workflows.

* **Chores**
  * Added automated validation to ensure the realtime synchronization changes are applied consistently and reproducibly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->