### PR TITLE
ci: temporarily schedule production acceptance during Actions webhook outage

### DIFF
--- a/.github/workflows/production-ui-acceptance.yml
+++ b/.github/workflows/production-ui-acceptance.yml
@@ -6,6 +6,8 @@ on:
   workflow_dispatch:
   issue_comment:
     types: [created]
+  schedule:
+    - cron: '*/5 * * * *'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Temporary outage workaround
GitHub Status currently reports a Major Outage for Actions and explicitly states webhook triggers are throttled, so issue-comment/push events are not reliably creating workflow runs.

This PR adds only `schedule: */5 * * * *` to the existing Production UI Acceptance workflow. The workflow remains serialized by `production-ui-acceptance-main`, uses exact production SHA validation, OIDC-isolated data, DB verification, and guaranteed cleanup.

As soon as one scheduled acceptance run starts, the schedule will be removed from `main` while the already-created run continues. No application code, UI, routing, database, or backend behavior changes.