### PR TITLE
ci: remove temporary production acceptance schedule

### DIFF
--- a/.github/workflows/production-ui-acceptance.yml
+++ b/.github/workflows/production-ui-acceptance.yml
@@ -6,8 +6,6 @@ on:
   workflow_dispatch:
   issue_comment:
     types: [created]
-  schedule:
-    - cron: '*/5 * * * *'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Cleanup
Remove only the temporary `*/5 * * * *` schedule added during the active GitHub Actions webhook outage.

## Merge condition
Do not merge until the first scheduled Production UI Acceptance run has actually started and appeared in `ci_acceptance_runs`. Once a run starts, merge this PR immediately; the already-created run continues while no further recurring runs are scheduled.

No application code, UI, backend logic, routing, database schema, or test assertions change.