### PR TITLE
test: remove false realtime race from production acceptance

### DIFF
--- a/tests/production/recruitment-realtime-acceptance.spec.js
+++ b/tests/production/recruitment-realtime-acceptance.spec.js
@@ -127,6 +127,9 @@ async function runDoctorTransition({ doctorPage, patientPages, doctor, clinicId,
   await expect(doctorPage.getByText(clinicId, { exact: true })).toBeVisible();
 
   const runAndObserve = async (buttonName, label) => {
+    const actionButton = doctorPage.getByRole('button', { name: buttonName });
+    await expect(actionButton).toBeEnabled();
+
     const previousVersions = await Promise.all(patientPages.map((page) => numericAttribute(
       page,
       '[data-test="patient-page"], [data-test="completion-screen"]',
@@ -137,8 +140,7 @@ async function runDoctorTransition({ doctorPage, patientPages, doctor, clinicId,
       '[data-test="patient-page"], [data-test="completion-screen"]',
       'data-realtime-events',
     )));
-    const actionButton = doctorPage.getByRole('button', { name: buttonName });
-    await expect(actionButton).toBeEnabled();
+
     const startedAt = Date.now();
     await actionButton.click();
     await Promise.all(patientPages.map((page, index) => waitForRealtimeEvent(page, previousEvents[index], startedAt, label)));


### PR DESCRIPTION
## Root cause
The recruitment acceptance captured route/event baselines before waiting for the doctor action button to become enabled. A legitimate earlier broadcast during that wait could increment the event counter before `startedAt`, producing a false `broadcast timestamp missing` failure.

## Fix
- Wait until the requested doctor action is enabled first.
- Then capture both phone baselines immediately before `startedAt` and click.
- Keep the same strict 2.5 second Broadcast and route-version limits.

## Non-goals
- No application code change.
- No visual or medical workflow change.
- No relaxation of realtime timing thresholds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved recruitment workflow test reliability by verifying that action buttons are available and enabled before proceeding with state synchronization and transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->