### PR TITLE
test: inventory semantic headings in production acceptance

### DIFF
--- a/tests/production/full-application-acceptance.spec.js
+++ b/tests/production/full-application-acceptance.spec.js
@@ -88,7 +88,7 @@ async function inventory(page, testInfo, name, { screenshot = true } = {}) {
     }));
   });
 
-  const headings = await page.locator('h1, h2, h3, h4').evaluateAll((elements) => elements
+  const headings = await page.locator('h1, h2, h3, h4, [role="heading"]').evaluateAll((elements) => elements
     .filter((element) => element.getClientRects().length)
     .map((element) => (element.innerText || element.textContent || '').trim().replace(/\s+/g, ' '))
     .filter(Boolean));


### PR DESCRIPTION
## Root cause
The production display page had a visible semantic heading (confirmed by `getByRole('heading')`), but acceptance inventory counted only literal `h1..h4` elements and falsely reported zero headings for AUD.

## Fix
- Inventory literal headings plus `[role="heading"]`.
- Do not change application code, UI, routing, medical workflow, or timing thresholds.

The temporary materializer will be removed from the final PR diff before merge.