### PR TITLE
fix: dedupe queue Broadcast versions and align doctor acceptance

### DIFF
--- a/frontend/src/components/PatientPageThemeAware.jsx
+++ b/frontend/src/components/PatientPageThemeAware.jsx
@@ -85,6 +85,7 @@ export function PatientPageThemeAware({ patientData, onLogout, language, toggleL
   const [realtimeLastEventAt, setRealtimeLastEventAt] = useState(0);
   const [routeVersionUpdatedAt, setRouteVersionUpdatedAt] = useState(0);
   const routeVersionRef = useRef(0);
+  const lastRealtimeEventVersionRef = useRef(0);
   const channelRef = useRef(null);
   const pollTimerRef = useRef(null);
   const noticeTimerRef = useRef(null);
@@ -272,9 +273,14 @@ export function PatientPageThemeAware({ patientData, onLogout, language, toggleL
       .on('broadcast', { event: 'queue_changed' }, (message) => {
         const receivedAt = Date.now();
         const payload = message?.payload || message || {};
+        const incomingVersion = Number(payload.version || 0);
+        if (Number.isFinite(incomingVersion) && incomingVersion > 0) {
+          if (incomingVersion <= lastRealtimeEventVersionRef.current) return;
+          lastRealtimeEventVersionRef.current = incomingVersion;
+        }
         setRealtimeLastEventAt(receivedAt);
         setRealtimeEventCount((count) => count + 1);
-        applyRouteVersion(payload.version, receivedAt);
+        applyRouteVersion(incomingVersion, receivedAt);
 
         const nextStep = Number(payload.current_step);
         const nextStatus = String(payload.status || '').trim().toLowerCase();

--- a/tests/production/full-application-acceptance.spec.js
+++ b/tests/production/full-application-acceptance.spec.js
@@ -150,7 +150,8 @@ async function loginDoctor(page, doctor) {
   const form = await fillVisibleCredentials(page, doctor.username, doctor.password);
   await form.getByRole('button', { name: /دخول الطبيب|Doctor Login/i }).click();
   await page.waitForURL(/\/doctor(?:\/|$)/, { timeout: 30_000 });
-  await expect(page.getByText(doctor.username, { exact: false }).first()).toBeVisible();
+  await expect(page.getByText(/لوحة الطبيب|Doctor dashboard/i)).toBeVisible();
+  await expect(page.getByRole('heading', { name: doctor.name, exact: true })).toBeVisible();
 }
 
 async function loginPatient(page, patientId, examType) {


### PR DESCRIPTION
## Scope
- Deduplicate duplicate database/REST queue broadcasts by canonical queue version before refreshing patient state.
- Keep the first Broadcast for each new version observable for the strict two-phone acceptance gate.
- Align the legacy doctor journey acceptance assertion with the doctor name actually displayed after successful login.

## Safety
- No visual identity changes.
- No queue state-machine or weighted-routing changes.
- No polling interval changes.
- No authentication changes.
- Temporary transformer/workflow files will be removed from the final PR diff before merge.

## Verification
Deterministic transform assertions, Typecheck, production Vite build, standard CI guards, backend #135 deployment first, then full production OIDC acceptance.