### PR TITLE
fix: enforce signed atomic patient device restriction

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,5 @@
 import { LoginPage } from './components/LoginPage.jsx';
-import { checkDeviceLogin, registerDeviceLogin, logDailyActivity, getSystemSetting } from './lib/supabase-client';
+import { checkDeviceLogin, logDailyActivity, getSystemSetting } from './lib/supabase-client';
 import React, { useState, useEffect, lazy, Suspense } from 'react';
 import { SpeedInsights } from '@vercel/speed-insights/react';
 import { Analytics } from '@vercel/analytics/react';
@@ -237,17 +237,6 @@ function App() {
         console.warn('[App] getSystemSetting failed:', settingError);
       }
 
-      if (deviceRestrictionEnabled) {
-        try {
-          const check = await checkDeviceLogin(patientId);
-          if (!check.allowed) {
-            showNotification(`هذا الجهاز مسجل برقم آخر اليوم: ${check.existingPatientId}`, 'error');
-            return;
-          }
-        } catch (deviceError) {
-          console.warn('[App] checkDeviceLogin failed, continuing login:', deviceError);
-        }
-      }
 
       const response = await api.patientLogin(patientId, gender);
       if (!response.success) {
@@ -268,17 +257,34 @@ function App() {
       localStorage.removeItem('mmc_admin_session');
       localStorage.removeItem('mmc_doctor_session');
       localStorage.removeItem('mmc_clinic_session');
+      // Persist the signed session before invoking patient-scoped Supabase RPCs.
       localStorage.setItem('patientData', JSON.stringify(finalPatientData));
+
+      if (deviceRestrictionEnabled) {
+        try {
+          const check = await checkDeviceLogin(patientId);
+          if (!check.allowed) {
+            localStorage.removeItem('patientData');
+            showNotification(
+              language === 'ar' ? 'هذا الجهاز مسجل برقم آخر اليوم' : 'This device is already registered to another patient today',
+              'error',
+            );
+            return;
+          }
+        } catch (deviceError) {
+          localStorage.removeItem('patientData');
+          console.error('[App] signed device guard failed:', deviceError);
+          showNotification(
+            language === 'ar' ? 'تعذر التحقق الآمن من الجهاز' : 'Secure device verification failed',
+            'error',
+          );
+          return;
+        }
+      }
+
       setIsAdmin(false);
       setDoctorSession(null);
       setPatientData(finalPatientData);
-
-      // Persist the signed patient session before writes protected by patient-scoped RLS.
-      try {
-        await registerDeviceLogin(patientId);
-      } catch (registrationError) {
-        console.warn('[App] registerDeviceLogin failed:', registrationError);
-      }
 
       try {
         await logDailyActivity('patient_login', {

--- a/frontend/src/lib/supabase-client.ts
+++ b/frontend/src/lib/supabase-client.ts
@@ -266,67 +266,37 @@ export function generateDeviceFingerprint() {
  * التحقق من تسجيل الجهاز لهذا اليوم
  * @returns {Promise<{allowed: boolean, existingPatientId?: string}>}
  */
-export async function checkDeviceLogin(patientId: string) {
-  try {
-    const deviceFingerprint = generateDeviceFingerprint();
-    const today = new Date().toISOString().split('T')[0];
+export async function checkDeviceLogin(_patientId?: string) {
+  const deviceFingerprint = generateDeviceFingerprint();
+  const { data, error } = await supabase.rpc('mmc_device_login_guard', {
+    p_device_fingerprint: deviceFingerprint,
+    p_user_agent: navigator.userAgent,
+  });
 
-    // التحقق من وجود تسجيل سابق لهذا الجهاز اليوم
-    const { data: existingLogin, error } = await supabase
-      .from('device_logins')
-      .select('patient_id')
-      .eq('device_fingerprint', deviceFingerprint)
-      .eq('login_date', today)
-      .maybeSingle();
-
-    if (error) {
-      console.error('خطأ في التحقق من الجهاز:', error);
-      // في حالة الخطأ، نسمح بالدخول مع تحذير
-      return { allowed: true, warning: 'تعذر التحقق من الجهاز' };
-    }
-
-    if (existingLogin && existingLogin.patient_id !== patientId) {
-      return {
-        allowed: false,
-        existingPatientId: existingLogin.patient_id,
-        message: 'هذا الجهاز مسجل برقم آخر اليوم',
-      };
-    }
-
-    return { allowed: true };
-  } catch (error) {
-    console.error('خطأ في checkDeviceLogin:', error);
-    return { allowed: true, warning: 'تعذر التحقق من الجهاز' };
+  if (error) {
+    console.error('خطأ في التحقق الآمن من الجهاز:', error);
+    throw error;
   }
+
+  const result = (Array.isArray(data) ? data[0] : data) as {
+    allowed?: boolean;
+    registered?: boolean;
+    reason?: string;
+  } | null;
+  return {
+    allowed: result?.allowed === true,
+    registered: result?.registered === true,
+    reason: typeof result?.reason === 'string' ? result.reason : undefined,
+    message: result?.allowed === true ? undefined : 'هذا الجهاز مسجل برقم آخر اليوم',
+  };
 }
 
 /**
  * تسجيل دخول الجهاز
  */
 export async function registerDeviceLogin(patientId: string): Promise<boolean> {
-  try {
-    const deviceFingerprint = generateDeviceFingerprint();
-
-    const { error } = await supabase
-      .from('device_logins')
-      .upsert({
-        device_fingerprint: deviceFingerprint,
-        patient_id: patientId,
-        login_date: new Date().toISOString().split('T')[0],
-        user_agent: navigator.userAgent,
-      }, {
-        onConflict: 'device_fingerprint,login_date',
-      });
-
-    if (error) {
-      console.error('خطأ في تسجيل الجهاز:', error);
-    }
-
-    return !error;
-  } catch (error) {
-    console.error('خطأ في registerDeviceLogin:', error);
-    return false;
-  }
+  const result = await checkDeviceLogin(patientId);
+  return result.allowed === true;
 }
 
 /**


### PR DESCRIPTION
## Scope
- Move the one-device-per-day check after signed patient session issuance.
- Replace direct browser reads/upserts on `device_logins` with the signed `mmc_device_login_guard` RPC.
- Fail closed only when the device restriction feature is enabled; the current production setting remains unchanged (`false`).
- Preserve the current UI and all medical routing/queue behavior.

## Safety
- No visual identity changes.
- No route, weight, clinic lock, doctor, or statistics logic changes.
- No disclosure of another patient's identifier.
- No secrets or permanent test data.

## Gate
Materialize a clean two-file commit, pass Frontend CI/Secret Scan/Duplicate Guard, merge only after backend migration is ready, then rerun full production Chromium acceptance against the exact deployed commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device verification by performing checks after sign-in using signed authentication data.
  * Removed the previous unsigned pre-login device check.
  * Added clearer localized notifications when device verification fails.
  * Automatically clears the session when verification cannot be completed.
  * Improved device login validation using device fingerprint and browser information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->