### PR TITLE
fix: stop redundant patient route refresh after completion

### DIFF
--- a/frontend/src/components/PatientPageThemeAware.jsx
+++ b/frontend/src/components/PatientPageThemeAware.jsx
@@ -262,7 +262,7 @@ export function PatientPageThemeAware({ patientData, onLogout, language, toggleL
   useEffect(() => { void loadPathway(); }, [loadPathway]);
 
   useEffect(() => {
-    if (!patientId || !activeQueueId) return undefined;
+    if (!patientId || !activeQueueId || allCompleted) return undefined;
     if (channelRef.current) {
       supabase.removeChannel(channelRef.current);
       channelRef.current = null;
@@ -284,6 +284,7 @@ export function PatientPageThemeAware({ patientData, onLogout, language, toggleL
 
         const nextStep = Number(payload.current_step);
         const nextStatus = String(payload.status || '').trim().toLowerCase();
+        const terminalStatus = ['done', 'completed'].includes(nextStatus);
         if (Number.isFinite(nextStep)) {
           setStations((previous) => previous.map((station, index) => {
             if (['done', 'completed'].includes(nextStatus) || index < nextStep) {
@@ -294,7 +295,7 @@ export function PatientPageThemeAware({ patientData, onLogout, language, toggleL
           }));
         }
 
-        void refreshJourney({ enterIfMissing: false });
+        if (!terminalStatus) void refreshJourney({ enterIfMissing: false });
       })
       .subscribe((status) => setRealtimeStatus(status));
 
@@ -306,10 +307,10 @@ export function PatientPageThemeAware({ patientData, onLogout, language, toggleL
       }
       setRealtimeStatus('CLOSED');
     };
-  }, [activeQueueId, applyRouteVersion, patientId, refreshJourney]);
+  }, [activeQueueId, allCompleted, applyRouteVersion, patientId, refreshJourney]);
 
   useEffect(() => {
-    if (!patientId) return undefined;
+    if (!patientId || allCompleted) return undefined;
     let inFlight = false;
     pollTimerRef.current = window.setInterval(() => {
       if (inFlight || document.visibilityState === 'hidden') return;
@@ -320,7 +321,7 @@ export function PatientPageThemeAware({ patientData, onLogout, language, toggleL
     return () => {
       if (pollTimerRef.current) window.clearInterval(pollTimerRef.current);
     };
-  }, [patientId, refreshJourney]);
+  }, [allCompleted, patientId, refreshJourney]);
 
   useEffect(() => {
     if (!patientId) return undefined;


### PR DESCRIPTION
## Cause
The completion screen kept the five-second route polling and queue Broadcast refresh path alive after every station was already complete. Navigating out could therefore cancel a redundant in-flight `route/get` request and surface `net::ERR_ABORTED` in strict production acceptance.

## Fix
- Stop route polling once all stations are complete.
- Close the queue Broadcast subscription once the route is complete.
- Do not launch another route refresh from a terminal `DONE/completed` Broadcast event.

## Safety
- No visual changes.
- No medical route, weighting, queue transition, clinic lock, doctor, or statistics changes.
- No credentials or persistent test data.

## Gate
A clean one-file commit is materialized from exact production commit `24ed0e9...`, then Frontend CI, Secret Scan, Duplicate Guard, production deployment, and full Chromium production acceptance must all pass.