### PR TITLE
fix: align admin diagnostics with signed production schema contracts

### DIFF
--- a/frontend/src/components/APIMonitor.jsx
+++ b/frontend/src/components/APIMonitor.jsx
@@ -101,184 +101,100 @@ const APIMonitor = ({ language = 'ar', t }) => {
 
   const monitoringInterval = useRef(null);
 
-  // فحص جدول واحد
+  // فحص جدول واحد عبر metadata RPC موقّعة للإدارة فقط
   const checkTable = useCallback(async (tableName) => {
+    const startTime = Date.now();
     try {
-      const startTime = Date.now();
-      const { data, error } = await supabase
-        .from(tableName)
-        .select('*')
-        .limit(1);
-      
-      const responseTime = Date.now() - startTime;
-      
-      if (error) {
-        return {
-          name: tableName,
-          status: 'error',
-          error: error.message,
-          responseTime,
-          lastCheck: new Date().toISOString(),
-          rowCount: 0
-        };
-      }
-      
+      const { data, error } = await supabase.rpc('mmc_admin_schema_health', {
+        p_tables: [tableName],
+        p_functions: [],
+      });
+      if (error) throw error;
+      const row = data?.tables?.[0];
       return {
         name: tableName,
-        status: 'active',
-        responseTime,
+        status: row?.exists ? 'active' : 'error',
+        error: row?.exists ? undefined : 'TABLE_NOT_FOUND',
+        responseTime: Date.now() - startTime,
         lastCheck: new Date().toISOString(),
-        rowCount: Array.isArray(data) ? data.length : 0
+        rowCount: Number(row?.estimated_rows || 0),
       };
     } catch (err) {
       return {
         name: tableName,
         status: 'error',
-        error: err.message,
-        responseTime: 0,
+        error: err?.message || String(err),
+        responseTime: Date.now() - startTime,
         lastCheck: new Date().toISOString(),
-        rowCount: 0
+        rowCount: 0,
       };
     }
   }, []);
 
-  // فحص دالة واحدة
+  // فحص دالة واحدة عبر catalog metadata فقط؛ لا يتم تنفيذ الدالة التشغيلية
   const checkFunction = useCallback(async (funcName) => {
+    const startTime = Date.now();
     try {
-      const startTime = Date.now();
-      
-      // محاولة استدعاء الدالة بدون معاملات للتحقق من وجودها
-      let error = null;
-      try {
-        const result = await supabase.rpc(funcName, {});
-        error = result.error;
-      } catch (_e) {
-        error = null; // function exists but threw
-      }
-      
-      const responseTime = Date.now() - startTime;
-      
-      // إذا كان الخطأ بسبب معاملات مفقودة، فالدالة موجودة
-      if (error && error.message && error.message.includes('argument')) {
-        return {
-          name: funcName,
-          status: 'active',
-          responseTime,
-          lastCheck: new Date().toISOString(),
-          note: 'requires parameters'
-        };
-      }
-      
+      const { data, error } = await supabase.rpc('mmc_admin_schema_health', {
+        p_tables: [],
+        p_functions: [funcName],
+      });
+      if (error) throw error;
+      const row = data?.functions?.[0];
       return {
         name: funcName,
-        status: error ? 'warning' : 'active',
-        responseTime,
+        status: row?.exists ? 'active' : 'error',
+        error: row?.exists ? undefined : 'FUNCTION_NOT_FOUND',
+        responseTime: Date.now() - startTime,
         lastCheck: new Date().toISOString(),
-        error: error?.message
       };
     } catch (err) {
       return {
         name: funcName,
-        status: 'active', // نفترض أنها موجودة إذا حدث خطأ في الاستدعاء
-        responseTime: 0,
+        status: 'error',
+        error: err?.message || String(err),
+        responseTime: Date.now() - startTime,
         lastCheck: new Date().toISOString(),
-        note: 'exists but requires specific parameters'
       };
     }
   }, []);
 
-  // ✅ نظام الإصلاح التلقائي المحسّن - يصلح سياسات RLS والاتصالات
+  // الإصلاح التلقائي هنا يتحقق من العقد فقط ولا يحاول تجاوز RLS أو لمس بيانات محمية
   const autoHeal = useCallback(async (item, type) => {
     if (!autoHealEnabled) return false;
-    
+
     const healingEntry = {
       id: Date.now(),
       type,
       item: item.name,
       timestamp: new Date().toISOString(),
-      action: 'attempting',
+      action: 'verifying_contract',
       success: false,
-      attempts: 0,
-      maxAttempts: 3
+      attempts: 1,
+      maxAttempts: 1,
     };
-    
+
     setHealingLog(prev => [healingEntry, ...prev.slice(0, 99)]);
     setStats(prev => ({ ...prev, healingAttempts: prev.healingAttempts + 1 }));
-    
+
     try {
-      if (type === 'table') {
-        // محاولة 1: إعادة الاتصال البسيط
-        healingEntry.attempts++;
-        const { error: firstError } = await supabase.from(item.name).select('*').limit(1);
-        
-        if (!firstError) {
-          healingEntry.action = 'reconnected';
-          healingEntry.success = true;
-          setStats(prev => ({ ...prev, successfulHeals: prev.successfulHeals + 1 }));
-          addAlert('success', `✅ تم إصلاح الاتصال بجدول ${item.name} تلقائياً`);
-          return true;
-        }
-        
-        // محاولة 2: التحقق من نوع الخطأ والإصلاح المناسب
-        if (firstError.code === '42501' || firstError.message?.includes('permission denied')) {
-          // خطأ صلاحيات RLS - نحاول القراءة بطريقة أخرى
-          healingEntry.attempts++;
-          healingEntry.action = 'rls_bypass_attempt';
-          
-          // محاولة القراءة بحد 1 فقط
-          const { error: limitedError } = await supabase.from(item.name).select('id').limit(1);
-          
-          if (!limitedError) {
-            healingEntry.action = 'limited_access_ok';
-            healingEntry.success = true;
-            setStats(prev => ({ ...prev, successfulHeals: prev.successfulHeals + 1 }));
-            addAlert('warning', `⚠️ جدول ${item.name} يعمل بصلاحيات محدودة`);
-            return true;
-          }
-          
-          // إضافة تنبيه بالمشكلة
-          addAlert('error', `❌ جدول ${item.name} يحتاج إصلاح سياسات RLS يدوياً`);
-          healingEntry.action = 'needs_manual_rls_fix';
-          return false;
-        }
-        
-        // محاولة 3: إعادة المحاولة بعد تأخير
-        healingEntry.attempts++;
-        await new Promise(resolve => setTimeout(resolve, 1000));
-        const { error: retryError } = await supabase.from(item.name).select('*').limit(1);
-        
-        if (!retryError) {
-          healingEntry.action = 'reconnected_after_retry';
-          healingEntry.success = true;
-          setStats(prev => ({ ...prev, successfulHeals: prev.successfulHeals + 1 }));
-          addAlert('success', `✅ تم إصلاح ${item.name} بعد إعادة المحاولة`);
-          return true;
-        }
-        
-      } else if (type === 'function') {
-        // محاولة إعادة فحص الدالة
-        const result = await checkFunction(item.name);
-        if (result.status === 'active') {
-          healingEntry.action = 'verified';
-          healingEntry.success = true;
-          setStats(prev => ({ ...prev, successfulHeals: prev.successfulHeals + 1 }));
-          addAlert('success', `✅ تم التحقق من دالة ${item.name} بنجاح`);
-          return true;
-        }
+      const result = type === 'table'
+        ? await checkTable(item.name)
+        : await checkFunction(item.name);
+      healingEntry.success = result.status === 'active';
+      healingEntry.action = healingEntry.success ? 'contract_verified' : 'contract_missing';
+      if (healingEntry.success) {
+        setStats(prev => ({ ...prev, successfulHeals: prev.successfulHeals + 1 }));
       }
-      
-      healingEntry.action = 'failed';
-      addAlert('error', `❌ فشل الإصلاح التلقائي لـ ${item.name}`);
-      return false;
+      return healingEntry.success;
     } catch (err) {
       healingEntry.action = 'error';
-      healingEntry.error = err.message;
-      addAlert('error', `❌ خطأ في إصلاح ${item.name}: ${err.message}`);
+      healingEntry.error = err?.message || String(err);
       return false;
     } finally {
       setHealingLog(prev => prev.map(h => h.id === healingEntry.id ? healingEntry : h));
     }
-  }, [autoHealEnabled, checkFunction]);
+  }, [autoHealEnabled, checkFunction, checkTable]);
 
   // إضافة تنبيه
   const addAlert = useCallback((type, message) => {

--- a/frontend/src/components/AdminDashboardV2.jsx
+++ b/frontend/src/components/AdminDashboardV2.jsx
@@ -822,11 +822,20 @@ const ReportsSection = ({ language, t }) => {
         };
       }) || [];
 
-      // جلب مسارات المرضى لحساب نسبة الإنجاز بالأوزان
-      const { data: patientRoutes } = await supabase
-        .from('patient_routes')
-        .select('patient_id, stations, current_station_index, status')
-        .gte('created_at', weekAgo.toISOString());
+      // جلب المسار القانوني من queues مع أوزان العيادات الحالية
+      const [{ data: patientRoutes }, { data: clinicWeights }] = await Promise.all([
+        supabase
+          .from('queues')
+          .select('patient_id,path,current_step,status')
+          .gte('created_at', weekAgo.toISOString()),
+        supabase
+          .from('clinics')
+          .select('id,weight'),
+      ]);
+      const weightByClinic = new Map((clinicWeights || []).map((clinic) => [
+        String(clinic.id),
+        Number(clinic.weight || 1),
+      ]));
 
       const completed = weekData?.filter(q => ['completed','done'].includes(q.status)) || [];
       const avgWait = completed.length > 0
@@ -842,10 +851,12 @@ const ReportsSection = ({ language, t }) => {
       let avgWeightedCompletion = 0;
       if (patientRoutes && patientRoutes.length > 0) {
         const totalCompletion = patientRoutes.reduce((sum, route) => {
-          const stations = typeof route.stations === 'string' 
-            ? JSON.parse(route.stations) 
-            : route.stations;
-          const currentIndex = route.current_station_index || 0;
+          const path = Array.isArray(route.path) ? route.path : [];
+          const stations = path.map((clinicId) => ({
+            id: String(clinicId),
+            weight: weightByClinic.get(String(clinicId)) || 1,
+          }));
+          const currentIndex = Number(route.current_step || 0);
           return sum + calculateWeightedCompletion(stations, currentIndex);
         }, 0);
         avgWeightedCompletion = Math.round(totalCompletion / patientRoutes.length);
@@ -2179,7 +2190,7 @@ const _OldDoctorManagement_ViewOnly = ({ language, t }) => {
         .from('unified_queue')
         .update({
           status: 'serving',
-          entered_clinic_at: new Date().toISOString()
+          exam_start_time: new Date().toISOString()
         })
         .eq('id', patient.id);
 
@@ -3409,21 +3420,15 @@ const SettingsSection = ({ language, t }) => {
   const loadSettings = async () => {
     try {
       setLoading(true);
-      // استخدام RPC get_all_settings للحصول على كل الإعدادات دفعة واحدة
-      const { data, error } = await supabase.rpc('get_all_settings');
-      if (!error && data?.success && data?.settings) {
-        setSettings(data.settings);
-        setLocalValues(data.settings);
-      } else {
-        // fallback: قراءة مباشرة
-        const { data: rows } = await supabase.from('system_settings').select('*');
-        const obj = {};
-        (rows || []).forEach(s => {
-          try { obj[s.id] = JSON.parse(s.value); } catch { obj[s.id] = s.value; }
-        });
-        setSettings(obj);
-        setLocalValues(obj);
-      }
+      // system_settings هو المصدر الحالي؛ تجنب RPC legacy غير الممنوحة للمتصفح
+      const { data: rows, error } = await supabase.from('system_settings').select('*');
+      if (error) throw error;
+      const obj = {};
+      (rows || []).forEach((setting) => {
+        try { obj[setting.id] = JSON.parse(setting.value); } catch { obj[setting.id] = setting.value; }
+      });
+      setSettings(obj);
+      setLocalValues(obj);
     } catch (e) {
       console.error('loadSettings error:', e);
     } finally {

--- a/frontend/src/components/FilesCenter.jsx
+++ b/frontend/src/components/FilesCenter.jsx
@@ -48,13 +48,13 @@ const DEFAULT_CATEGORIES = [
 ];
 
 const normalizeDoc = (doc = {}) => ({
-  id: String(doc.id ?? doc.path ?? doc.name ?? crypto.randomUUID()),
+  id: String(doc.id ?? doc.name ?? crypto.randomUUID()),
   name: doc.name_ar || doc.name || 'Untitled',
-  fullName: doc.name || doc.name_ar || 'Untitled',
+  fullName: doc.full_name || doc.name_en || doc.name || doc.name_ar || 'Untitled',
   category: doc.category || 'docs',
-  path: doc.path || '',
+  path: '',
   content: doc.content || '',
-  description: doc.description || doc.description_ar || '',
+  description: doc.description || '',
   updated_at: doc.updated_at || null,
 });
 
@@ -83,7 +83,7 @@ const FilesCenter = ({ language = 'ar' }) => {
     try {
       const { data, error: dbError } = await supabase
         .from('system_docs')
-        .select('id,name,name_ar,category,path,content,description,description_ar,updated_at')
+        .select('id,name,name_ar,name_en,full_name,category,content,description,updated_at')
         .order('category', { ascending: true })
         .order('name', { ascending: true });
 


### PR DESCRIPTION
## Cause
Post-release PostgreSQL review showed the admin screens were generating avoidable 4xx database errors by probing protected table rows, invoking operational RPCs for existence checks, and using legacy columns that no longer exist.

## Fix
- Use the signed `mmc_admin_schema_health` metadata RPC for API Monitor table/function existence checks; never probe protected rows or execute operational functions just to discover them.
- Remove the pseudo-RLS bypass behavior from API Monitor auto-heal; contract verification is metadata-only.
- Align Files Center with the current `system_docs` schema.
- Read weighted route statistics from canonical `queues.path/current_step` plus current clinic weights.
- Use the current queue exam-start timestamp contract.
- Read settings directly from canonical `system_settings` instead of the legacy browser-inaccessible `get_all_settings` RPC.

## Safety
- No visual identity changes.
- No patient medical-route, queue transition, clinic-lock, doctor, realtime, or weighting algorithm changes.
- No permission widening and no secrets.

## Gate
Materialize a clean three-file commit from exact production commit `2e13b24...`, pass Frontend CI/Secret Scan/Duplicate Guard, deploy, then rerun full production Chromium acceptance and inspect PostgreSQL logs for zero repeated legacy-probe errors.