### PR TITLE
fix: resolve direct deep links before the first render

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -104,7 +104,24 @@ function App() {
   const [doctorSession, setDoctorSession] = useState(() => readValidSession('mmc_doctor_session'));
   const [patientData, setPatientData] = useState(() => readValidSession('patientData'));
   const [isAdmin, setIsAdmin] = useState(() => Boolean(authService.getSession()));
-  const [currentView, setCurrentView] = useState('login');
+  const [currentView, setCurrentView] = useState(() => {
+    if (typeof window === 'undefined') return 'login';
+    const path = window.location.pathname;
+
+    if (/\/clinic\/[^/]+\/display$/.test(path)) return 'display';
+    if (path.includes('/qr')) return 'qrscan';
+    if (path === '/admin' || path.startsWith('/admin/')) return isAdmin ? 'admin' : 'login';
+    if (
+      path === '/doctor'
+      || path.startsWith('/doctor/')
+      || path === '/clinic/login'
+      || path === '/clinic/login/'
+      || path.startsWith('/clinic/')
+    ) return doctorSession ? 'doctor' : 'login';
+    if (isAdmin) return 'admin';
+    if (patientData) return patientData.queueType || patientData.examType ? 'patient' : 'examSelection';
+    return 'login';
+  });
   const [currentTheme, setCurrentTheme] = useState(() => {
     try {
       return localStorage.getItem('selectedTheme') || 'medical-professional';


### PR DESCRIPTION
## Cause
Direct `/clinic/:id/display` navigation rendered the default login view for one frame before the location-sync effect switched to the lazy display view. This produced a visible login/loading flash and made display acceptance race against the wrong initial heading.

## Fix
Derive `currentView` synchronously from `window.location.pathname` and the already-restored signed sessions in the `useState` initializer. The existing popstate/location effect remains the source for subsequent navigation changes.

## Safety
- No visual redesign.
- No queue, route, weighting, doctor, realtime, statistics, or API logic changes.
- No permission changes and no secrets.

## Gate
Materialize a clean one-file commit from exact production commit `8145cebd...`, pass Frontend CI/Secret Scan/Duplicate Guard, deploy, then rerun full production Chromium acceptance and PostgreSQL-log review.