### PR TITLE
fix: align DoctorControl queue select with current schema

### DIFF
--- a/frontend/src/components/DoctorControl.jsx
+++ b/frontend/src/components/DoctorControl.jsx
@@ -73,7 +73,7 @@ const DoctorControl = ({ language = 'ar', t = (ar) => ar, doctorId, clinicId }) 
           'id','display_number','patient_id',
           'military_id','personal_id','gender','exam_type',
           'status','entered_at','called_at','exam_start_time',
-          'exam_end_time','completed_at','entered_clinic_at',
+          'exam_end_time','completed_at',
           'is_vip','is_priority','is_military_committee','notes','queue_date'
         ].join(','))
         .eq('clinic_id', selectedClinic)


### PR DESCRIPTION
## Cause
The final PostgreSQL log review found one remaining production 4xx error: `DoctorControl` still selected legacy column `unified_queue.entered_clinic_at`, which no longer exists. The component does not use that field.

## Fix
Remove only the obsolete field from the `unified_queue` select list.

## Safety
- One-line application change only.
- No visual changes.
- No route, queue transition, doctor action, statistics, realtime, or weighting behavior changes.
- No permissions or secrets changed.

## Gate
Materialize a clean one-file commit from exact production commit `bc9da537...`, pass Frontend CI/Secret Scan/Duplicate Guard, deploy, then rerun full production Chromium acceptance and verify PostgreSQL logs contain no new application ERROR entries during the run.